### PR TITLE
Add "Prune Inactive Chats" feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,6 +207,40 @@
       "required": false,
       "type": "password",
       "default": ""
+    },
+    {
+      "name": "inactiveDuration",
+      "title": "Delete Inactive Chats After...",
+      "description": "Duration of inactivity before chat is deleted.",
+      "required": false,
+      "type": "dropdown",
+      "default": "Disabled",
+      "data": [
+        {
+          "title": "Disabled",
+          "value": "0"
+        },
+        {
+          "title": "1 Day",
+          "value": "1"
+        },
+        {
+          "title": "3 Days",
+          "value": "3"
+        },
+        {
+          "title": "1 Week",
+          "value": "7"
+        },
+        {
+          "title": "1 Month",
+          "value": "30"
+        },
+        {
+          "title": "6 Months",
+          "value": "180"
+        }
+      ]
     }
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -201,24 +201,28 @@
           "value": "0"
         },
         {
+          "title": "6 Hours",
+          "value": "6"
+        },
+        {
           "title": "1 Day",
-          "value": "1"
+          "value": "24"
         },
         {
           "title": "3 Days",
-          "value": "3"
+          "value": "72"
         },
         {
           "title": "1 Week",
-          "value": "7"
+          "value": "168"
         },
         {
           "title": "1 Month",
-          "value": "30"
+          "value": "720"
         },
         {
           "title": "6 Months",
-          "value": "180"
+          "value": "4320"
         }
       ]
     }

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -10,7 +10,7 @@ import {
   LocalStorage,
   showToast,
   Toast,
-  useNavigation
+  useNavigation,
 } from "@raycast/api";
 import { useEffect, useState } from "react";
 import { defaultProvider, formatResponse, getChatResponse, processChunks, providers } from "./api/gpt";
@@ -132,14 +132,14 @@ export default function Chat({ launchContext }) {
         lastMessageTime = new Date(lastMessageTime).getTime();
         const prune = currentTime - lastMessageTime >= pruneChatsLimit;
         if (prune) prunedCnt++;
-        return !prune;  // false if pruned
+        return !prune; // false if pruned
       });
 
       console.log(`Pruned ${prunedCnt} chats`);
       newChatData.lastPruneTime = currentTime;
       return newChatData;
     });
-  }
+  };
 
   let CreateChat = () => {
     const { pop } = useNavigation();


### PR DESCRIPTION
Automatically delete inactive chats after a set interval (in preferences).

This is done by calling the pruneChats function every time an AI chat generation completes. But it only performs the search every 30 minutes (defined by pruneChatsInterval), so performance impact is very minimal.