### PR TITLE
Add Web Search capabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     {
       "name": "webSearch",
       "label": "Enable Web Search (BETA)",
-      "description": "Use web search together with GPT, whenever possible.",
+      "description": "Adds web search capabilities to GPT. Available in AI Chat.",
       "required": false,
       "type": "checkbox",
       "default": false

--- a/package.json
+++ b/package.json
@@ -212,6 +212,22 @@
       "default": "GPT4"
     },
     {
+      "name": "webSearch",
+      "label": "Enable Web Search (BETA)",
+      "description": "Use web search together with GPT, whenever possible.",
+      "required": false,
+      "type": "checkbox",
+      "default": false
+    },
+    {
+      "name": "TavilyAPIKey",
+      "title": "Tavily API Key",
+      "description": "Optional. Only used if Web Search is enabled.",
+      "required": false,
+      "type": "password",
+      "default": ""
+    },
+    {
       "name": "GeminiAPIKey",
       "title": "Google Gemini API Key",
       "description": "Optional. Only used if Gemini model is selected.",

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -140,7 +140,9 @@ export default function Chat({ launchContext }) {
     const [provider, model, stream] = providers[currentChat.provider];
     const useWebSearch = getPreferenceValues()["webSearch"];
 
-    let elapsed = 0.001, chars, charPerSec;
+    let elapsed = 0.001,
+      chars,
+      charPerSec;
     let start = new Date().getTime();
     let response = "";
 

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -72,7 +72,7 @@ export default function Chat({ launchContext }) {
       creationDate: creationDate,
       provider: provider,
       systemPrompt: systemPrompt,
-      messages: messages ? messages : starting_messages(systemPrompt, provider),
+      messages: messages?.length ? messages : starting_messages(systemPrompt, provider),
     };
   };
 

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -10,7 +10,7 @@ import {
   LocalStorage,
   showToast,
   Toast,
-  useNavigation
+  useNavigation,
 } from "@raycast/api";
 import { useEffect, useState } from "react";
 import { defaultProvider, formatResponse, getChatResponse, processChunks, providers } from "./api/gpt";
@@ -56,14 +56,18 @@ export default function Chat({ launchContext }) {
   let default_all_chats_data = () => {
     return {
       currentChat: "New Chat",
-      chats: [
-        chat_data({})
-      ],
+      chats: [chat_data({})],
       lastPruneTime: new Date().getTime(),
     };
   };
 
-  let chat_data = ({name = "New Chat", creationDate = new Date(), provider = defaultProvider(), systemPrompt = "", messages = []}) => {
+  let chat_data = ({
+    name = "New Chat",
+    creationDate = new Date(),
+    provider = defaultProvider(),
+    systemPrompt = "",
+    messages = [],
+  }) => {
     return {
       name: name,
       creationDate: creationDate,
@@ -71,9 +75,16 @@ export default function Chat({ launchContext }) {
       systemPrompt: systemPrompt,
       messages: starting_messages(systemPrompt, provider),
     };
-  }
+  };
 
-  let message_data = ({prompt = "", answer = "", creationDate = new Date(), id = new Date().getTime(), finished = false, visible = true}) => {
+  let message_data = ({
+    prompt = "",
+    answer = "",
+    creationDate = new Date(),
+    id = new Date().getTime(),
+    finished = false,
+    visible = true,
+  }) => {
     return {
       prompt: prompt,
       answer: answer,
@@ -90,10 +101,10 @@ export default function Chat({ launchContext }) {
       systemPrompt += "\n\n" + webSystemPrompt;
     }
     if (systemPrompt) {
-      messages.push(message_data({prompt: systemPrompt, answer: systemResponse, visible: false}));
+      messages.push(message_data({ prompt: systemPrompt, answer: systemResponse, visible: false }));
     }
     return messages;
-  }
+  };
 
   let _setChatData = async (chatData, setChatData, messageID, query = null, response = null, finished = null) => {
     setChatData((oldData) => {
@@ -121,16 +132,16 @@ export default function Chat({ launchContext }) {
       }
       return newChatData;
     });
-  }
+  };
 
   let updateChatResponse = async (chatData, setChatData, messageID, query = null, previousWebSearch = false) => {
     await _setChatData(chatData, setChatData, messageID, query, ""); // will not overwrite prompt if query is null
 
     let currentChat = getChat(chatData.currentChat, chatData.chats);
-      for (const msg of currentChat.messages) {
+    for (const msg of currentChat.messages) {
       console.log("prompt: " + msg.prompt);
       console.log("answer: " + msg.answer);
-      }
+    }
     const [provider, model, stream] = providers[currentChat.provider];
     const useWebSearch = getPreferenceValues()["webSearch"];
 
@@ -159,10 +170,16 @@ export default function Chat({ launchContext }) {
 
         // Web Search functionality
         // We check the response every few chunks so we can possibly exit early
-        if ((i & 15) === 0 && useWebSearch && response.includes(webToken) && response.includes(webTokenEnd) && !previousWebSearch) {
-            generationStatus.stop = true; // stop generating the current response
-            await processWebSearchResponse(chatData, setChatData, currentChat, messageID, response, query);
-            return;
+        if (
+          (i & 15) === 0 &&
+          useWebSearch &&
+          response.includes(webToken) &&
+          response.includes(webTokenEnd) &&
+          !previousWebSearch
+        ) {
+          generationStatus.stop = true; // stop generating the current response
+          await processWebSearchResponse(chatData, setChatData, currentChat, messageID, response, query);
+          return;
         }
 
         elapsed = (new Date().getTime() - start) / 1000;
@@ -175,9 +192,9 @@ export default function Chat({ launchContext }) {
     // Web Search functionality
     // Process web search response again in case streaming is false, or if it was not processed during streaming
     if (useWebSearch && response.includes(webToken) && !previousWebSearch) {
-        generationStatus.stop = true;
-        await processWebSearchResponse(chatData, setChatData, currentChat, messageID, response, query);
-        return;
+      generationStatus.stop = true;
+      await processWebSearchResponse(chatData, setChatData, currentChat, messageID, response, query);
+      return;
     }
 
     await _setChatData(chatData, setChatData, messageID, null, null, true);
@@ -282,7 +299,7 @@ export default function Chat({ launchContext }) {
           messages.unshift(currentMessage);
         }
         let time = Number(line.replace("<|start_message_token|>", "").replace("<|end_message_token|>", ""));
-        currentMessage = message_data({creationDate: new Date(time), finished: true});
+        currentMessage = message_data({ creationDate: new Date(time), finished: true });
       } else if (line.startsWith("<|start_prompt_token|>")) {
         currentState = "prompt";
       } else if (line.startsWith("<|end_prompt_token|>") || line.startsWith("<|end_response_token|>")) {
@@ -306,17 +323,19 @@ export default function Chat({ launchContext }) {
 
     setChatData((oldData) => {
       let newChatData = structuredClone(oldData);
-      newChatData.chats.push(chat_data({
-        name: `Imported at ${new Date().toLocaleString("en-US", {
-          month: "2-digit",
-          day: "2-digit",
-          hour: "2-digit",
-          minute: "2-digit",
-          second: "2-digit",
-        })}`,
-        provider: provider,
-        messages: messages,
-      }));
+      newChatData.chats.push(
+        chat_data({
+          name: `Imported at ${new Date().toLocaleString("en-US", {
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+            second: "2-digit",
+          })}`,
+          provider: provider,
+          messages: messages,
+        })
+      );
       newChatData.currentChat = newChatData.chats[newChatData.chats.length - 1].name;
       return newChatData;
     });
@@ -345,7 +364,9 @@ export default function Chat({ launchContext }) {
                   pop();
                   setChatData((oldData) => {
                     let newChatData = structuredClone(oldData);
-                    newChatData.chats.push(chat_data({name: values.chatName, provider: values.provider, systemPrompt: values.systemPrompt}));
+                    newChatData.chats.push(
+                      chat_data({ name: values.chatName, provider: values.provider, systemPrompt: values.systemPrompt })
+                    );
                     newChatData.currentChat = values.chatName;
 
                     return newChatData;
@@ -394,22 +415,22 @@ export default function Chat({ launchContext }) {
     setSearchText("");
     toast(Toast.Style.Animated, "Response Loading");
 
-      let currentChat = getChat(chatData.currentChat, chatData.chats);
-      let newMessageID = new Date().getTime();
+    let currentChat = getChat(chatData.currentChat, chatData.chats);
+    let newMessageID = new Date().getTime();
 
-      currentChat.messages.unshift(message_data({prompt: query, id: newMessageID}));
-      updateCurrentChat(chatData, setChatData, currentChat);  // possibly redundant, put here for safety and consistency
+    currentChat.messages.unshift(message_data({ prompt: query, id: newMessageID }));
+    updateCurrentChat(chatData, setChatData, currentChat); // possibly redundant, put here for safety and consistency
 
-      try {
-        await updateChatResponse(chatData, setChatData, newMessageID, query);
-      } catch {
-        setChatData((oldData) => {
-          let newChatData = structuredClone(oldData);
-          getChat(chatData.currentChat, newChatData.chats).messages.shift();
-          return newChatData;
-        });
-        await toast(Toast.Style.Failure, "GPT cannot process this message.");
-      }
+    try {
+      await updateChatResponse(chatData, setChatData, newMessageID, query);
+    } catch {
+      setChatData((oldData) => {
+        let newChatData = structuredClone(oldData);
+        getChat(chatData.currentChat, newChatData.chats).messages.shift();
+        return newChatData;
+      });
+      await toast(Toast.Style.Failure, "GPT cannot process this message.");
+    }
   };
 
   let ComposeMessage = () => {
@@ -458,7 +479,7 @@ export default function Chat({ launchContext }) {
                 // but since prompt is changed, we need to update chat.messages[0].prompt,
                 // so we no longer insert a null message, and hence don't pass query to updateChatResponse.
                 chat.messages.shift();
-                chat.messages.unshift(message_data({prompt: values.message}));
+                chat.messages.unshift(message_data({ prompt: values.message }));
                 updateCurrentChat(chatData, setChatData, chat);
                 let messageID = chat.messages[0].id;
                 updateChatResponse(chatData, setChatData, messageID).then(() => {
@@ -520,29 +541,30 @@ export default function Chat({ launchContext }) {
 
   // Web Search functionality
   const processWebSearchResponse = async (chatData, setChatData, currentChat, messageID, response, query) => {
-  await _setChatData(chatData, setChatData, messageID, null, null, false);
-  await showToast(Toast.Style.Animated, "Searching Web");
-  // get everything AFTER webToken and BEFORE webTokenEnd
-  let webQuery = response.includes(webTokenEnd) ? response.substring(response.indexOf(webToken) + webToken.length, response.indexOf(webTokenEnd)).trim()
-    : response.substring(response.indexOf(webToken) + webToken.length).trim();
-  let webResponse = await getWebResult(webQuery);
-  webResponse = `\n\n<|web_search_results|> for "${webQuery}":\n\n` + webResponse;
+    await _setChatData(chatData, setChatData, messageID, null, null, false);
+    await showToast(Toast.Style.Animated, "Searching Web");
+    // get everything AFTER webToken and BEFORE webTokenEnd
+    let webQuery = response.includes(webTokenEnd)
+      ? response.substring(response.indexOf(webToken) + webToken.length, response.indexOf(webTokenEnd)).trim()
+      : response.substring(response.indexOf(webToken) + webToken.length).trim();
+    let webResponse = await getWebResult(webQuery);
+    webResponse = `\n\n<|web_search_results|> for "${webQuery}":\n\n` + webResponse;
 
-  // Append web search results to the last user message
-  // special case: If e.g. the message was edited, query is not passed as a parameter, so it is null
-  if (!query) query = currentChat.messages[0].prompt;
-  let newQuery = query + webResponse;
+    // Append web search results to the last user message
+    // special case: If e.g. the message was edited, query is not passed as a parameter, so it is null
+    if (!query) query = currentChat.messages[0].prompt;
+    let newQuery = query + webResponse;
 
-  // remove latest message (similar to edit message)
-  currentChat.messages.shift();
-  currentChat.messages.unshift(message_data({prompt: newQuery}));
-  let newMessageID = currentChat.messages[0].id;
+    // remove latest message (similar to edit message)
+    currentChat.messages.shift();
+    currentChat.messages.unshift(message_data({ prompt: newQuery }));
+    let newMessageID = currentChat.messages[0].id;
 
-  updateCurrentChat(chatData, setChatData, currentChat);  // important to update the UI!
+    updateCurrentChat(chatData, setChatData, currentChat); // important to update the UI!
 
-  await updateChatResponse(chatData, setChatData, newMessageID, null, true);
-  return;
-  }
+    await updateChatResponse(chatData, setChatData, newMessageID, null, true);
+    return;
+  };
 
   let GPTActionPanel = () => {
     return (
@@ -856,12 +878,12 @@ export default function Chat({ launchContext }) {
             minute: "2-digit",
             second: "2-digit",
           })}`;
-          newChatData.chats.push(chat_data({
-            name: newChatName,
-            messages: [
-              message_data({prompt: launchContext.query, answer: launchContext.response, finished: true}),
-            ],
-          }));
+          newChatData.chats.push(
+            chat_data({
+              name: newChatName,
+              messages: [message_data({ prompt: launchContext.query, answer: launchContext.response, finished: true })],
+            })
+          );
           newChatData.currentChat = newChatName;
           return newChatData;
         });
@@ -945,4 +967,4 @@ const isChatEmpty = (chat) => {
     if (message.visible) return false;
   }
   return true;
-}
+};

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -72,7 +72,7 @@ export default function Chat({ launchContext }) {
       creationDate: creationDate,
       provider: provider,
       systemPrompt: systemPrompt,
-      messages: starting_messages(systemPrompt, provider),
+      messages: messages ? messages : starting_messages(systemPrompt, provider),
     };
   };
 

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -15,7 +15,6 @@ import {
 import { useEffect, useState } from "react";
 import { defaultProvider, formatResponse, getChatResponse, processChunks, providers } from "./api/gpt";
 import { formatDate } from "./api/helper";
-import fetch from "node-fetch-polyfill";
 
 // Web search module
 import { getWebResult } from "./api/web";
@@ -138,10 +137,6 @@ export default function Chat({ launchContext }) {
     await _setChatData(chatData, setChatData, messageID, query, ""); // will not overwrite prompt if query is null
 
     let currentChat = getChat(chatData.currentChat, chatData.chats);
-    for (const msg of currentChat.messages) {
-      console.log("prompt: " + msg.prompt);
-      console.log("answer: " + msg.answer);
-    }
     const [provider, model, stream] = providers[currentChat.provider];
     const useWebSearch = getPreferenceValues()["webSearch"];
 

--- a/src/api/Providers/deepinfra.jsx
+++ b/src/api/Providers/deepinfra.jsx
@@ -23,11 +23,12 @@ const headers = {
   "sec-ch-ua-platform": '"macOS"',
 };
 
-export const getDeepInfraResponse = async function* (chat, model, max_retries = 5) {
+export const getDeepInfraResponse = async function* (chat, options, max_retries = 5) {
+  const model = options.model;
   let data = {
     model: model,
     messages: chat,
-    temperature: 0.7,
+    temperature: options.temperature || 0.7,
     max_tokens: model.includes("Meta-Llama-3") ? 1028 : null,
     stream: true,
     headers: headers,

--- a/src/api/Providers/deepinfra.jsx
+++ b/src/api/Providers/deepinfra.jsx
@@ -76,7 +76,7 @@ export const getDeepInfraResponse = async function* (chat, options, max_retries 
   } catch (e) {
     if (max_retries > 0) {
       console.log(e, "Retrying...");
-      yield* getDeepInfraResponse(chat, model, max_retries - 1);
+      yield* getDeepInfraResponse(chat, options, max_retries - 1);
     } else {
       throw e;
     }

--- a/src/api/Providers/replicate.jsx
+++ b/src/api/Providers/replicate.jsx
@@ -78,7 +78,7 @@ export const getReplicateResponse = async function* (chat, options, max_retries 
   } catch (e) {
     if (max_retries > 0) {
       console.log(e, "Retrying...");
-      yield* getReplicateResponse(chat, model, max_retries - 1);
+      yield* getReplicateResponse(chat, options, max_retries - 1);
     } else {
       throw e;
     }

--- a/src/api/Providers/replicate.jsx
+++ b/src/api/Providers/replicate.jsx
@@ -10,14 +10,16 @@ const headers = {
   "Content-Type": "application/json",
 };
 
-export const getReplicateResponse = async function* (chat, model, max_retries = 10) {
+export const getReplicateResponse = async function* (chat, options, max_retries = 10) {
+  const model = options.model;
+
   let data = {
     stream: true,
     input: {
       prompt: formatChatToPrompt(chat, model),
       max_tokens: model.includes("meta-llama-3") ? 512 : null, // respected by meta-llama-3
       max_new_tokens: model.includes("mixtral") ? 1024 : null, // respected by mixtral-8x7b
-      temperature: 0.7,
+      temperature: options.temperature || 0.7,
     },
   };
 

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -394,9 +394,10 @@ export const chatCompletion = async (chat, options) => {
 // generate response using a chat context and a query (optional)
 export const getChatResponse = async (currentChat, query = null) => {
   let chat = [];
-  if (currentChat.systemPrompt.length > 0)
-    // The system prompt is not acknowledged by most providers, so we use it as first user prompt instead
-    chat.push({ role: "user", content: currentChat.systemPrompt });
+  // if (currentChat.systemPrompt.length > 0)
+  //   // The system prompt is not acknowledged by most providers, so we use it as first user prompt instead
+  //   chat.push({ role: "user", content: currentChat.systemPrompt });
+  // The above section is deprecated because we currently already push system prompt to start of chat
 
   // currentChat.messages is stored in the format of [prompt, answer]. We first convert it to
   // { role: "user", content: prompt }, { role: "assistant", content: answer }, etc.

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -57,7 +57,7 @@ export const provider_options = (provider) => {
   return {
     temperature: temperature,
   };
-}
+};
 
 export const defaultProvider = () => {
   return getPreferenceValues()["gptProvider"];
@@ -400,7 +400,8 @@ export const getChatResponse = async (currentChat, query = null) => {
 
   // currentChat.messages is stored in the format of [prompt, answer]. We first convert it to
   // { role: "user", content: prompt }, { role: "assistant", content: answer }, etc.
-  for (let i = currentChat.messages.length - 1; i >= 0; i--) { // reverse order, index 0 is latest message
+  for (let i = currentChat.messages.length - 1; i >= 0; i--) {
+    // reverse order, index 0 is latest message
     let message = currentChat.messages[i];
     if (is_null_message(message)) continue;
     chat.push({ role: "user", content: message.prompt });

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -52,7 +52,7 @@ export const providers = {
 // Additional options
 export const provider_options = (provider) => {
   let useWebSearch = getPreferenceValues()["webSearch"];
-  let temperature = useWebSearch ? 0 : 0.7;
+  let temperature = useWebSearch ? 0.3 : 0.7;
 
   return {
     temperature: temperature,

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -52,7 +52,7 @@ export const providers = {
 // Additional options
 export const provider_options = (provider) => {
   let useWebSearch = getPreferenceValues()["webSearch"];
-  let temperature = useWebSearch ? 0.3 : 0.7;
+  let temperature = useWebSearch ? 0.5 : 0.7;
 
   return {
     temperature: temperature,

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -49,6 +49,16 @@ export const providers = {
   GoogleGemini: [GeminiProvider, "", false],
 };
 
+// Additional options
+export const provider_options = (provider) => {
+  let useWebSearch = getPreferenceValues()["webSearch"];
+  let temperature = useWebSearch ? 0 : 0.7;
+
+  return {
+    temperature: temperature,
+  };
+}
+
 export const defaultProvider = () => {
   return getPreferenceValues()["gptProvider"];
 };
@@ -357,13 +367,13 @@ export const chatCompletion = async (chat, options) => {
   const provider = options.provider;
   if (provider === DeepInfraProvider) {
     // Deep Infra Llama 3
-    response = await getDeepInfraResponse(chat, options.model);
+    response = await getDeepInfraResponse(chat, options);
   } else if (provider === BlackboxProvider) {
     // Blackbox
     response = await getBlackboxResponse(chat);
   } else if (provider === ReplicateProvider) {
     // Replicate
-    response = await getReplicateResponse(chat, options.model);
+    response = await getReplicateResponse(chat, options);
   } else if (provider === GeminiProvider) {
     // Google Gemini
     response = await getGoogleGeminiResponse(chat);
@@ -382,7 +392,7 @@ export const chatCompletion = async (chat, options) => {
 };
 
 // generate response using a chat context and a query (optional)
-export const getChatResponse = async (currentChat, query) => {
+export const getChatResponse = async (currentChat, query = null) => {
   let chat = [];
   if (currentChat.systemPrompt.length > 0)
     // The system prompt is not acknowledged by most providers, so we use it as first user prompt instead
@@ -390,22 +400,26 @@ export const getChatResponse = async (currentChat, query) => {
 
   // currentChat.messages is stored in the format of [prompt, answer]. We first convert it to
   // { role: "user", content: prompt }, { role: "assistant", content: answer }, etc.
-  for (let i = currentChat.messages.length - 1; i >= 0; i--) {
-    if (is_null_message(currentChat.messages[i])) continue;
-    // reverse order, index 0 is latest message
-    chat.push({ role: "user", content: currentChat.messages[i].prompt });
-    chat.push({ role: "assistant", content: currentChat.messages[i].answer });
+  for (let i = currentChat.messages.length - 1; i >= 0; i--) { // reverse order, index 0 is latest message
+    let message = currentChat.messages[i];
+    if (is_null_message(message)) continue;
+    chat.push({ role: "user", content: message.prompt });
+    if (message.answer) chat.push({ role: "assistant", content: message.answer });
   }
-  if (query?.length > 0) chat.push({ role: "user", content: query });
+  if (query) chat.push({ role: "user", content: query });
 
   // load provider and model
   const providerString = currentChat.provider;
   const [provider, model, stream] = providers[providerString];
-  const options = {
+  let options = {
     provider: provider,
     model: model,
     stream: stream,
   };
+
+  // additional options
+  options = { ...options, ...provider_options(provider) };
+  console.log(options);
 
   // generate response
   return await chatCompletion(chat, options);

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -420,7 +420,6 @@ export const getChatResponse = async (currentChat, query = null) => {
 
   // additional options
   options = { ...options, ...provider_options(provider) };
-  console.log(options);
 
   // generate response
   return await chatCompletion(chat, options);

--- a/src/api/web.jsx
+++ b/src/api/web.jsx
@@ -39,6 +39,11 @@ export const getWebResult = async (query) => {
 };
 
 export const processWebResults = (results) => {
+  // Handle undefined results
+  if (!results) {
+    return "No results found.";
+  }
+
   let answer = "";
   for (let i = 0; i < results.length; i++) {
     let x = results[i];

--- a/src/api/web.jsx
+++ b/src/api/web.jsx
@@ -1,8 +1,10 @@
 import { getPreferenceValues } from "@raycast/api";
 import fetch from "node-fetch-polyfill";
 
-export const webToken = "<|web_search|>", webTokenEnd = "<|end_web_search|>";
-export const webSystemPrompt = "You are given access to make searches on the Internet. The format for making a search" +
+export const webToken = "<|web_search|>",
+  webTokenEnd = "<|end_web_search|>";
+export const webSystemPrompt =
+  "You are given access to make searches on the Internet. The format for making a search" +
   " is: 1. The user sends a message. 2. You will decide whether to make a search. If you choose to make a search, you will " +
   "output a single message, containing the word <|web_search|> (EXACTLY AS IT IS GIVEN TO YOU), followed by ONLY your web search query. " +
   "After outputting your search query, you MUST output the token <|end_web_search|> (EXACTLY AS IT IS GIVEN TO YOU) to denote the end of the search query. " +
@@ -16,31 +18,31 @@ export const webSystemPrompt = "You are given access to make searches on the Int
 export const systemResponse = "Understood. I will strictly follow these instructions in this conversation.";
 
 export const getWebResult = async (query) => {
-    const APIKey = getPreferenceValues()["TavilyAPIKey"];
-    const api_url = "https://api.tavily.com/search";
-    let data = {
-      "api_key": APIKey,
-      "query": query,
-      "max_results": 5,
-    };
-    // POST
-    const response = await fetch(api_url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(data),
-    });
+  const APIKey = getPreferenceValues()["TavilyAPIKey"];
+  const api_url = "https://api.tavily.com/search";
+  let data = {
+    api_key: APIKey,
+    query: query,
+    max_results: 5,
+  };
+  // POST
+  const response = await fetch(api_url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
 
-    const responseJson = await response.json();
-    return processWebResults(responseJson["results"]);
-  }
+  const responseJson = await response.json();
+  return processWebResults(responseJson["results"]);
+};
 
-  export const processWebResults = (results) => {
-    let answer = "";
-    for (let i = 0; i < results.length; i++) {
-      let x = results[i];
-      answer += x["title"] + "\n" + x["url"] + "\n" + x["content"] + "\n\n";
-    }
-    return answer;
+export const processWebResults = (results) => {
+  let answer = "";
+  for (let i = 0; i < results.length; i++) {
+    let x = results[i];
+    answer += x["title"] + "\n" + x["url"] + "\n" + x["content"] + "\n\n";
   }
+  return answer;
+};

--- a/src/api/web.jsx
+++ b/src/api/web.jsx
@@ -1,0 +1,46 @@
+import { getPreferenceValues } from "@raycast/api";
+import fetch from "node-fetch-polyfill";
+
+export const webToken = "<|web_search|>", webTokenEnd = "<|end_web_search|>";
+export const webSystemPrompt = "You are given access to make searches on the Internet. The format for making a search" +
+  " is: 1. The user sends a message. 2. You will decide whether to make a search. If you choose to make a search, you will " +
+  "output a single message, containing the word <|web_search|> (EXACTLY AS IT IS GIVEN TO YOU), followed by ONLY your web search query. " +
+  "After outputting your search query, you MUST output the token <|end_web_search|> (EXACTLY AS IT IS GIVEN TO YOU) to denote the end of the search query. " +
+  "Keep your search query concise as there is a 400 characters limit.\n" +
+  "The system will then append the web search results at the end of the user message, starting with the token <|web_search_results|>." +
+  " If this token <|web_search_results|> is present in the user's message, then you MUST NOT request another web search.\n" +
+  "You must NEVER output <|web_search_results|>, this token is reserved for the user to send.\n" +
+  "IMPORTANT! You should ONLY choose to search the web if it is STRONGLY relevant to the user's query. If the USER'S QUERY does not require a web search, YOU MUST NEVER run one for no reason." +
+  " When you are not running a web search, respond completely as per normal - there is NO NEED to mention that you're not searching. \n" +
+  "You MUST NOT make up any information.\n";
+export const systemResponse = "Understood. I will strictly follow these instructions in this conversation.";
+
+export const getWebResult = async (query) => {
+    const APIKey = getPreferenceValues()["TavilyAPIKey"];
+    const api_url = "https://api.tavily.com/search";
+    let data = {
+      "api_key": APIKey,
+      "query": query,
+      "max_results": 5,
+    };
+    // POST
+    const response = await fetch(api_url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    });
+
+    const responseJson = await response.json();
+    return processWebResults(responseJson["results"]);
+  }
+
+  export const processWebResults = (results) => {
+    let answer = "";
+    for (let i = 0; i < results.length; i++) {
+      let x = results[i];
+      answer += x["title"] + "\n" + x["url"] + "\n" + x["content"] + "\n\n";
+    }
+    return answer;
+  }


### PR DESCRIPTION
Adds basic Web Search capability that can be enabled in Preferences. **Currently only available in AI Chat**, will consider implementing into other AI commands later. Currently more testing of this feature needs to be done.

Summary: When the user sends a message, the AI decides for itself whether to run a web search. The [system prompt](https://github.com/XInTheDark/raycast-g4f/blob/web_search/src/api/web.jsx) is used to instruct the AI that it should request a web search only when it is strongly relevant to the user query.

Searches are done using the [Tavily API](https://docs.tavily.com/docs/tavily-api/introduction); an API Key needs to be provided in Preferences, and for the free plan there is a limit of 1000 requests/month.

Also included: many many refactors.

closes #19