### PR TITLE
Add "Smart Chat Naming" functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,8 +213,17 @@
     },
     {
       "name": "webSearch",
+      "title": "Experimental Features",
       "label": "Enable Web Search (BETA)",
       "description": "Adds web search capabilities to GPT. Available in AI Chat.",
+      "required": false,
+      "type": "checkbox",
+      "default": false
+    },
+    {
+      "name": "smartChatNaming",
+      "label": "Enable Smart Chat Naming (BETA)",
+      "description": "Automatically renames chat sessions based on the messages you send.",
       "required": false,
       "type": "checkbox",
       "default": false

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -218,28 +218,7 @@ export default function Chat({ launchContext }) {
 
     // Smart Chat Naming functionality
     if (getPreferenceValues()["smartChatNaming"] && currentChat.messages.length <= 2) {
-      // Special handling: don't include first message (system prompt)
-      let newChat = structuredClone(currentChat);
-      if (!newChat.messages[newChat.messages.length - 1].visible) {
-        newChat.messages.pop();
-      }
-
-      // Format chat using default wrapper
-      let formatted_chat = formatChatToPrompt(formatChatToGPT(newChat), null);
-      let newQuery =
-        "Below is a conversation between the user and the assistant. Give a concise name for this chat. " +
-        "Output ONLY the name of the chat (without quotes) and NOTHING else.\n\n" +
-        formatted_chat;
-
-      let newChatName = await getChatResponseSync({ messages: [{ prompt: newQuery }], provider: currentChat.provider });
-      newChatName = newChatName.trim();
-
-      // Rename chat
-      setChatData((oldData) => {
-        let newChatData = structuredClone(oldData);
-        getChat(chatData.currentChat, newChatData.chats).name = newChatName;
-        return newChatData;
-      });
+      await processSmartChatNaming(chatData, setChatData, currentChat);
     }
   };
 
@@ -615,6 +594,32 @@ export default function Chat({ launchContext }) {
     // Note how we don't pass query here because it is already in the chat
     await updateChatResponse(chatData, setChatData, newMessageID, null, true);
     return;
+  };
+
+  // Smart Chat Naming functionality
+  const processSmartChatNaming = async (chatData, setChatData, currentChat) => {
+    // Special handling: don't include first message (system prompt)
+    let newChat = structuredClone(currentChat);
+    if (!newChat.messages[newChat.messages.length - 1].visible) {
+      newChat.messages.pop();
+    }
+
+    // Format chat using default wrapper
+    let formatted_chat = formatChatToPrompt(formatChatToGPT(newChat), null);
+    let newQuery =
+      "Below is a conversation between the user and the assistant. Give a concise name for this chat. " +
+      "Output ONLY the name of the chat (without quotes) and NOTHING else.\n\n" +
+      formatted_chat;
+
+    let newChatName = await getChatResponseSync({ messages: [{ prompt: newQuery }], provider: currentChat.provider });
+    newChatName = newChatName.trim();
+
+    // Rename chat
+    setChatData((oldData) => {
+      let newChatData = structuredClone(oldData);
+      getChat(chatData.currentChat, newChatData.chats).name = newChatName;
+      return newChatData;
+    });
   };
 
   let GPTActionPanel = () => {

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -61,7 +61,6 @@ export default function Chat({ launchContext }) {
 
   let default_all_chats_data = () => {
     let newChat = chat_data({});
-    console.log("newChat" + newChat.id);
     return {
       currentChat: newChat.id,
       chats: [newChat],

--- a/src/api/helper.jsx
+++ b/src/api/helper.jsx
@@ -32,8 +32,33 @@ export const formatDate = (dateToCheckISO) => {
   return formatted;
 };
 
+// Format a series of messages into a GPT chat format
+// Takes a chat object (that we use in AI Chat) and a query, and returns a GPT chat format
+export const formatChatToGPT = (currentChat, query = null) => {
+  // if (currentChat.systemPrompt.length > 0)
+  //   // The system prompt is not acknowledged by most providers, so we use it as first user prompt instead
+  //   chat.push({ role: "user", content: currentChat.systemPrompt });
+  // The above section is deprecated because we currently already push system prompt to start of chat
+
+  let chat = [];
+
+  // currentChat.messages is stored in the format of [prompt, answer]. We first convert it to
+  // { role: "user", content: prompt }, { role: "assistant", content: answer }, etc.
+  for (let i = currentChat.messages.length - 1; i >= 0; i--) {
+    // reverse order, index 0 is latest message
+    let message = currentChat.messages[i];
+    if (is_null_message(message)) continue;
+    if (message.prompt) chat.push({ role: "user", content: message.prompt });
+    else continue;
+    if (message.answer) chat.push({ role: "assistant", content: message.answer });
+  }
+  if (query) chat.push({ role: "user", content: query });
+  return chat;
+};
+
 // Format a series of messages into a single string
-export const formatChatToPrompt = (chat, model) => {
+// Takes a GPT format chat (i.e. [{role: ..., content: ...}]) and returns a string
+export const formatChatToPrompt = (chat, model = null) => {
   model = model?.toLowerCase() || "";
   let prompt = "";
 
@@ -62,4 +87,8 @@ export const formatChatToPrompt = (chat, model) => {
   }
 
   return prompt;
+};
+
+export const is_null_message = (message) => {
+  return !message || ((message?.prompt || "").length === 0 && (message?.answer || "").length === 0);
 };


### PR DESCRIPTION
Add Smart Chat Naming functionality, similar to ChatGPT web UI. After the user's 1st (or 2nd) message, the AI automatically generates a concise name for the conversation.

Implementation details:
1. refactored chat data so that each chat now has an unique ID (based on creation time). This is to support multiple chats potentially having the same name.
2. moved a couple of functions into helper.jsx
3. also corrected the isShowingDetail logic so the empty chat screen for empty chats is now the same when Web Search is enabled.

Lightly tested.