### PR TITLE
Change gpt-3.5-turbo API to support streaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,12 +157,12 @@
       "type": "dropdown",
       "data": [
         {
-          "title": "ChatGPT (gpt-4-32k)",
-          "value": "GPT4"
-        },
-        {
           "title": "ChatGPT (gpt-3.5-turbo)",
           "value": "GPT35"
+        },
+        {
+          "title": "ChatGPT (gpt-4-32k)",
+          "value": "GPT4"
         },
         {
           "title": "Bing (gpt-4)",
@@ -209,7 +209,7 @@
           "value": "GoogleGemini"
         }
       ],
-      "default": "GPT4"
+      "default": "GPT35"
     },
     {
       "name": "webSearch",

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -442,9 +442,10 @@ export default function Chat({ launchContext }) {
     toast(Toast.Style.Animated, "Response Loading");
 
     let currentChat = getChat(chatData.currentChat, chatData.chats);
-    let newMessageID = new Date().getTime();
+    let newMessage = message_data({ prompt: query })
+    let newMessageID = newMessage.id;
 
-    currentChat.messages.unshift(message_data({ prompt: query, id: newMessageID }));
+    currentChat.messages.unshift(newMessage);
     updateCurrentChat(chatData, setChatData, currentChat); // possibly redundant, put here for safety and consistency
 
     try {

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -442,7 +442,7 @@ export default function Chat({ launchContext }) {
     toast(Toast.Style.Animated, "Response Loading");
 
     let currentChat = getChat(chatData.currentChat, chatData.chats);
-    let newMessage = message_data({ prompt: query })
+    let newMessage = message_data({ prompt: query });
     let newMessageID = newMessage.id;
 
     currentChat.messages.unshift(newMessage);

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -134,7 +134,7 @@ export default function Chat({ launchContext }) {
     setChatData((oldData) => {
       let newChatData = structuredClone(oldData);
       for (let i = 0; i < newChatData.chats.length; i++) {
-        if (newChatData.chats[i].name === chat.name) {
+        if (newChatData.chats[i].id === chat.id) {
           newChatData.chats[i] = chat;
           break;
         }
@@ -381,8 +381,6 @@ export default function Chat({ launchContext }) {
               onSubmit={(values) => {
                 if (values.chatName === "") {
                   toast(Toast.Style.Failure, "Chat name cannot be empty");
-                } else if (chatData.chats.map((x) => x.name).includes(values.chatName)) {
-                  toast(Toast.Style.Failure, "Chat with that name already exists");
                 } else {
                   pop();
                   setChatData((oldData) => {

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -171,7 +171,7 @@ export default function Chat({ launchContext }) {
 
       for await (const chunk of await processChunks(r, provider, get_status)) {
         i++;
-        response += chunk;
+        response = chunk;
         response = formatResponse(response, provider);
         await _setChatData(chatData, setChatData, messageID, null, response);
 

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -28,8 +28,8 @@ import { getWebResult } from "./api/web";
 import { webSystemPrompt, systemResponse, webToken, webTokenEnd } from "./api/web";
 
 const chat_providers = [
-  ["ChatGPT (gpt-4-32k)", "GPT4"],
   ["ChatGPT (gpt-3.5-turbo)", "GPT35"],
+  ["ChatGPT (gpt-4-32k)", "GPT4"],
   ["Bing (gpt-4)", "Bing"],
   ["DeepInfra (WizardLM-2-8x22B)", "DeepInfraWizardLM2_8x22B"],
   ["DeepInfra (meta-llama-3-8b)", "DeepInfraLlama3_8B"],

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -115,7 +115,7 @@ export default function Chat({ launchContext }) {
     return messages;
   };
 
-  let _setChatData = async (chatData, setChatData, messageID, query = null, response = null, finished = null) => {
+  let setCurrentChatData = async (chatData, setChatData, messageID, query = null, response = null, finished = null) => {
     setChatData((oldData) => {
       let newChatData = structuredClone(oldData);
       let messages = getChat(chatData.currentChat, newChatData.chats).messages;
@@ -144,7 +144,7 @@ export default function Chat({ launchContext }) {
   };
 
   let updateChatResponse = async (chatData, setChatData, messageID, query = null, previousWebSearch = false) => {
-    await _setChatData(chatData, setChatData, messageID, null, ""); // set response to empty string
+    await setCurrentChatData(chatData, setChatData, messageID, null, ""); // set response to empty string
 
     let currentChat = getChat(chatData.currentChat, chatData.chats);
     const [provider, model, stream] = providers[currentChat.provider];
@@ -158,7 +158,7 @@ export default function Chat({ launchContext }) {
 
     if (!stream) {
       response = await getChatResponse(currentChat, query);
-      await _setChatData(chatData, setChatData, messageID, null, response);
+      await setCurrentChatData(chatData, setChatData, messageID, null, response);
 
       elapsed = (new Date().getTime() - start) / 1000;
       chars = response.length;
@@ -173,7 +173,7 @@ export default function Chat({ launchContext }) {
         i++;
         response = chunk;
         response = formatResponse(response, provider);
-        await _setChatData(chatData, setChatData, messageID, null, response);
+        await setCurrentChatData(chatData, setChatData, messageID, null, response);
 
         // Web Search functionality
         // We check the response every few chunks so we can possibly exit early
@@ -204,7 +204,7 @@ export default function Chat({ launchContext }) {
       return;
     }
 
-    await _setChatData(chatData, setChatData, messageID, null, null, true);
+    await setCurrentChatData(chatData, setChatData, messageID, null, null, true);
 
     await toast(
       Toast.Style.Success,
@@ -568,7 +568,7 @@ export default function Chat({ launchContext }) {
 
   // Web Search functionality
   const processWebSearchResponse = async (chatData, setChatData, currentChat, messageID, response, query) => {
-    await _setChatData(chatData, setChatData, messageID, null, null, false);
+    await setCurrentChatData(chatData, setChatData, messageID, null, null, false);
     await showToast(Toast.Style.Animated, "Searching Web");
     // get everything AFTER webToken and BEFORE webTokenEnd
     let webQuery = response.includes(webTokenEnd)
@@ -591,7 +591,6 @@ export default function Chat({ launchContext }) {
 
     // Note how we don't pass query here because it is already in the chat
     await updateChatResponse(chatData, setChatData, newMessageID, null, true);
-    return;
   };
 
   // Smart Chat Naming functionality

--- a/src/api/Providers/blackbox.jsx
+++ b/src/api/Providers/blackbox.jsx
@@ -58,11 +58,12 @@ export const getBlackboxResponse = async function* (chat, max_retries = 5) {
     });
 
     let reader = response.body.getReader();
+    let decoder = new TextDecoder();
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
 
-      let chunk = new TextDecoder().decode(value);
+      let chunk = decoder.decode(value);
       if (chunk) {
         yield chunk;
       }

--- a/src/api/Providers/deepinfra.jsx
+++ b/src/api/Providers/deepinfra.jsx
@@ -45,11 +45,12 @@ export const getDeepInfraResponse = async function* (chat, options, max_retries 
     // Implementation taken from gpt4free: g4f/Provider/needs_auth/Openai.py at async def create_async_generator()
     let first = true;
     let reader = response.body.getReader();
+    let decoder = new TextDecoder();
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
 
-      let str = new TextDecoder().decode(value);
+      let str = decoder.decode(value);
       let lines = str.split("\n");
       for (let i = 0; i < lines.length; i++) {
         let line = lines[i];

--- a/src/api/Providers/nexra.jsx
+++ b/src/api/Providers/nexra.jsx
@@ -27,7 +27,6 @@ export const getNexraResponse = async function* (chat, options, max_retries = 5)
 
     const reader = response.body.getReader();
     let decoder = new TextDecoder();
-    let prevMsg = "";
 
     while (true) {
       const { done, value } = await reader.read();
@@ -53,15 +52,8 @@ export const getNexraResponse = async function* (chat, options, max_retries = 5)
         if (chunkJson["finish"]) break;
         // if (chunkJson["error"]) throw new Error();
 
-        let chunk = chunkJson["message"],
-          msg = chunk;
-        // remove prevMsg from chunk
-        chunk = removePrefix(chunk, prevMsg);
-
-        // Update prevMsg
-        prevMsg = msg;
-
-        yield chunk;
+        let chunk = chunkJson["message"];
+        yield chunk; // note that this is the full response, not just incremental updates!
       }
     }
   } catch (e) {

--- a/src/api/Providers/nexra.jsx
+++ b/src/api/Providers/nexra.jsx
@@ -40,7 +40,6 @@ export const getNexraResponse = async function* (chat, options, max_retries = 5)
       let arr = chunkStr.split(String.fromCharCode(30));
 
       for (const _chunk of arr) {
-        console.log(_chunk);
         let chunkJson;
         try {
           chunkJson = JSON.parse(_chunk);

--- a/src/api/Providers/replicate.jsx
+++ b/src/api/Providers/replicate.jsx
@@ -46,13 +46,14 @@ export const getReplicateResponse = async function* (chat, options, max_retries 
     });
 
     const reader = streamResponse.body.getReader();
+    let decoder = new TextDecoder();
     // eslint-disable-next-line no-constant-condition
     let curr_event = "";
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
 
-      let str = new TextDecoder().decode(value);
+      let str = decoder.decode(value);
 
       // iterate through each line
       // implementation ported from gpt4free.

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -400,7 +400,8 @@ export const getChatResponse = async (currentChat, query = null) => {
   let chat = formatChatToGPT(currentChat, query);
 
   // load provider and model
-  const providerString = currentChat?.provider || defaultProvider();
+  if (!currentChat.provider) currentChat.provider = defaultProvider();
+  const providerString = currentChat.provider;
   const [provider, model, stream] = providers[providerString];
   let options = {
     provider: provider,
@@ -421,11 +422,13 @@ export const getChatResponseSync = async (currentChat, query = null) => {
   if (typeof r === "string") {
     return r;
   }
+
+  const [provider, model, stream] = providers[currentChat.provider];
   let response = "";
-  for await (const chunk of r) {
-    response += chunk;
+  for await (const chunk of processChunks(r, provider)) {
+    response = chunk;
   }
-  response = formatResponse(response, currentChat?.provider);
+  response = formatResponse(response, currentChat.provider);
   return response;
 };
 

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -433,12 +433,16 @@ export const getChatResponseSync = async (currentChat, query = null) => {
 export const formatResponse = (response, provider = null) => {
   const is_code = response.includes("```");
 
-  if (provider === g4f.providers.Bing || !is_code) {
-    // replace \n with a real newline, \t with a real tab, etc.
-    // unless code blocks are detected and provider is not Bing
+  if (provider === g4f.providers.Bing || provider === NexraProvider || !is_code) {
+    // replace escape characters: \n with a real newline, \t with a real tab, etc.
     response = response.replace(/\\n/g, "\n");
     response = response.replace(/\\t/g, "\t");
     response = response.replace(/\\r/g, "\r");
+
+    // the following escape characters are still displayed correctly even without the replacement,
+    // but we currently have features that depend on stuff being in the response, for example
+    // web search that requires the <|web_search|> token to be present.
+    response = response.replace(/\\_/g, "_");
 
     // remove <sup>, </sup> tags (not supported apparently)
     response = response.replace(/<sup>/g, "");

--- a/src/api/helper.jsx
+++ b/src/api/helper.jsx
@@ -92,3 +92,33 @@ export const formatChatToPrompt = (chat, model = null) => {
 export const is_null_message = (message) => {
   return !message || ((message?.prompt || "").length === 0 && (message?.answer || "").length === 0);
 };
+
+export const removeFirstOccurrence = (str, substr) => {
+  let idx = str.indexOf(substr);
+  if (idx !== -1) {
+    return str.substring(idx + substr.length);
+  }
+  return str;
+};
+
+export const removeLastOccurrence = (str, substr) => {
+  let idx = str.lastIndexOf(substr);
+  if (idx !== -1) {
+    return str.substring(0, idx);
+  }
+  return str;
+};
+
+export const removePrefix = (str, prefix) => {
+  if (str.startsWith(prefix)) {
+    return str.substring(prefix.length);
+  }
+  return str;
+};
+
+export const removeSuffix = (str, suffix) => {
+  if (str.endsWith(suffix)) {
+    return str.substring(0, str.length - suffix.length);
+  }
+  return str;
+};

--- a/src/api/web.jsx
+++ b/src/api/web.jsx
@@ -9,9 +9,8 @@ export const webSystemPrompt =
   "output a single message, containing the word <|web_search|> (EXACTLY AS IT IS GIVEN TO YOU), followed by ONLY your web search query. " +
   "After outputting your search query, you MUST output the token <|end_web_search|> (EXACTLY AS IT IS GIVEN TO YOU) to denote the end of the search query. " +
   "Keep your search query concise as there is a 400 characters limit.\n" +
-  "The system will then append the web search results at the end of the user message, starting with the token <|web_search_results|>." +
-  " If this token <|web_search_results|> is present in the user's message, then you MUST NOT request another web search.\n" +
-  "You must NEVER output <|web_search_results|>, this token is reserved for the user to send.\n" +
+  "The system will then append the web search results at the end of the user message, starting with the token <|web_search_results|>. You can use these search results in your response." +
+  " If the token <|web_search_results|> is present in the user's message, then you MUST NOT request another web search.\n" +
   "IMPORTANT! You should ONLY choose to search the web if it is STRONGLY relevant to the user's query. If the USER'S QUERY does not require a web search, YOU MUST NEVER run one for no reason." +
   " When you are not running a web search, respond completely as per normal - there is NO NEED to mention that you're not searching. \n" +
   "You MUST NOT make up any information.\n";

--- a/src/api/web.jsx
+++ b/src/api/web.jsx
@@ -9,11 +9,18 @@ export const webSystemPrompt =
   "output a single message, containing the word <|web_search|> (EXACTLY AS IT IS GIVEN TO YOU), followed by ONLY your web search query. " +
   "After outputting your search query, you MUST output the token <|end_web_search|> (EXACTLY AS IT IS GIVEN TO YOU) to denote the end of the search query. " +
   "Keep your search query concise as there is a 400 characters limit.\n" +
-  "The system will then append the web search results at the end of the user message, starting with the token <|web_search_results|>. You can use these search results in your response." +
-  " If the token <|web_search_results|> is present in the user's message, then you MUST NOT request another web search.\n" +
-  "IMPORTANT! You should ONLY choose to search the web if it is STRONGLY relevant to the user's query. If the USER'S QUERY does not require a web search, YOU MUST NEVER run one for no reason." +
-  " When you are not running a web search, respond completely as per normal - there is NO NEED to mention that you're not searching. \n" +
-  "You MUST NOT make up any information.\n";
+  "The system will then append the web search results at the end of the user message, starting with the token <|web_search_results|>. " +
+  "Take note that the user CANNOT ACCESS the content under <|web_search_results|> - YOU should incorporate these results into your response. " +
+  "Additionally, If the token <|web_search_results|> is present in the user's message, then you MUST NOT request another web search.\n\n" +
+  "IMPORTANT! You should ONLY choose to search the web if it is STRONGLY relevant to the user's query, i.e. in the following circumstances: " +
+  "1. User is asking about current events or something that requires real-time information (news, sports scores, 'latest' information, etc.)\n" +
+  "2. User is asking about some term you are unfamiliar with - you don't have a good idea of what it is, or if it's a little-known term.\n" +
+  "3. User explicitly asks you to browse or provide links to references.\n" +
+  "If the user's query does NOT require a web search, YOU MUST NEVER run one for no reason.\n\n" +
+  "When using web search results, you are encouraged to cite references where appropriate, using inline links in standard markdown format.\n" +
+  "You are also allowed to make use of web search results from previous messages, if they are STRONGLY RELEVANT to the current message.\n\n" +
+  "When you are not running a web search, respond completely as per normal - there is NO NEED to mention that you're not searching. \n" +
+  "Do your best to be informative. However, you MUST NOT make up any information. If you think you might not know something, search for it.\n";
 export const systemResponse = "Understood. I will strictly follow these instructions in this conversation.";
 
 export const getWebResult = async (query) => {
@@ -46,7 +53,8 @@ export const processWebResults = (results) => {
   let answer = "";
   for (let i = 0; i < results.length; i++) {
     let x = results[i];
-    answer += x["title"] + "\n" + x["url"] + "\n" + x["content"] + "\n\n";
+    let rst = `Title: ${x["title"]}\nURL: ${x["url"]}\n${x["content"]}\n\n`;
+    answer += rst;
   }
   return answer;
 };


### PR DESCRIPTION
The new implementation uses the Nexra ChatGPT v2 API.
Because streaming is a pretty useful feature, this also changes the default provider to gpt-3.5-turbo.

Also includes:
- fix updateCurrentChat using name instead of id
- tweak web search prompt
- remove redundant "duplicate name" check in create chat
- update processChunks function to yield full response instead of incrementally