### PR TITLE
Improvements to Web Search

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,9 +229,9 @@
       "default": false
     },
     {
-      "name": "TavilyAPIKey",
-      "title": "Tavily API Key",
-      "description": "Optional. Only used if Web Search is enabled.",
+      "name": "TavilyAPIKeys",
+      "title": "Tavily API Keys",
+      "description": "Optional. Only used if Web Search is enabled. Multiple keys are supported - separate them with commas.",
       "required": false,
       "type": "password",
       "default": ""

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -605,7 +605,7 @@ export default function Chat({ launchContext }) {
     let formatted_chat = formatChatToPrompt(formatChatToGPT(newChat), null);
     let newQuery =
       "Below is a conversation between the user and the assistant. Give a concise name for this chat. " +
-      "Output ONLY the name of the chat (without quotes) and NOTHING else.\n\n" +
+      "Output ONLY the name of the chat (WITHOUT quotes) and NOTHING else.\n\n" +
       formatted_chat;
 
     let newChatName = await getChatResponseSync({ messages: [{ prompt: newQuery }], provider: currentChat.provider });

--- a/src/api/web.jsx
+++ b/src/api/web.jsx
@@ -12,10 +12,11 @@ export const webSystemPrompt =
   "The system will then append the web search results at the end of the user message, starting with the token <|web_search_results|>. " +
   "Take note that the user CANNOT ACCESS the content under <|web_search_results|> - YOU should incorporate these results into your response. " +
   "Additionally, If the token <|web_search_results|> is present in the user's message, then you MUST NOT request another web search.\n\n" +
-  "IMPORTANT! You should ONLY choose to search the web if it is STRONGLY relevant to the user's query, i.e. in the following circumstances: " +
+  "IMPORTANT! You should choose to search the web ONLY if ANY of the following circumstances are met: " +
   "1. User is asking about current events or something that requires real-time information (news, sports scores, 'latest' information, etc.)\n" +
   "2. User is asking about some term you are unfamiliar with - you don't have a good idea of what it is, or if it's a little-known term.\n" +
-  "3. User explicitly asks you to browse or provide links to references.\n" +
+  "3. User is asking about anything that involves numerical facts (e.g. distances between places, population count, sizes, date and time, etc.)\n" +
+  "4. User explicitly asks you to search or provide links to references.\n" +
   "If the user's query does NOT require a web search, YOU MUST NEVER run one for no reason.\n\n" +
   "When using web search results, you are encouraged to cite references where appropriate, using inline links in standard markdown format.\n" +
   "You are also allowed to make use of web search results from previous messages, if they are STRONGLY RELEVANT to the current message.\n\n" +

--- a/src/api/web.jsx
+++ b/src/api/web.jsx
@@ -45,6 +45,7 @@ export const getWebResult = async (query) => {
   return processWebResults(responseJson["results"]);
 };
 
+// Wrapper for returning web results in a readable format
 export const processWebResults = (results) => {
   // Handle undefined results
   if (!results) {
@@ -54,7 +55,7 @@ export const processWebResults = (results) => {
   let answer = "";
   for (let i = 0; i < results.length; i++) {
     let x = results[i];
-    let rst = `Title: ${x["title"]}\nURL: ${x["url"]}\n${x["content"]}\n\n`;
+    let rst = `${i + 1}.\nURL: ${x["url"]}\nTitle: ${x["title"]}\nContent: ${x["content"]}\n\n`;
     answer += rst;
   }
   return answer;

--- a/src/api/web.jsx
+++ b/src/api/web.jsx
@@ -14,7 +14,7 @@ export const webSystemPrompt =
   "Additionally, If the token <|web_search_results|> is present in the user's message, then you MUST NOT request another web search.\n\n" +
   "IMPORTANT! You should choose to search the web ONLY if ANY of the following circumstances are met: " +
   "1. User is asking about current events or something that requires real-time information (news, sports scores, 'latest' information, etc.)\n" +
-  "2. User is asking about some term you are unfamiliar with - you don't have a good idea of what it is, or if it's a little-known term.\n" +
+  "2. User is asking about some term you are unfamiliar with (e.g. if it's a little-known term, if it's a person you don't know well, etc.)\n" +
   "3. User is asking about anything that involves numerical facts (e.g. distances between places, population count, sizes, date and time, etc.)\n" +
   "4. User explicitly asks you to search or provide links to references.\n" +
   "If the user's query does NOT require a web search, YOU MUST NEVER run one for no reason.\n\n" +


### PR DESCRIPTION
- better system prompt
- tweaks to web search wrapper

- I  have set the "search_depth" parameter in the Tavily API to "advanced" which yields better search results, but at the cost of using 2 requests. The current "solution" is to allow pasting of multiple Tavily API Keys in preferences, so that we can fallback one by one in case the rate limit is reached. 