### PR TITLE
Add Google Gemini provider back

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@raycast/api": "^1.62.0",
         "@raycast/utils": "^1.9.0",
         "g4f": "^1.4.2",
+        "gemini-ai": "^1.1.0",
         "node-fetch-polyfill": "^2.0.6"
       },
       "devDependencies": {
@@ -1307,6 +1308,11 @@
         "axios": "^1.6.5",
         "signale": "^1.4.0"
       }
+    },
+    "node_modules/gemini-ai": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gemini-ai/-/gemini-ai-1.1.0.tgz",
+      "integrity": "sha512-T9dU6Nz+Y0q/7QEfFEtRxVUcg+Kq3HHY//4tVO+NsWJMXufQfREWFyeqbUcogSZVYxZBxDEdUl538NECeEFeeg=="
     },
     "node_modules/glob": {
       "version": "7.2.3",

--- a/package.json
+++ b/package.json
@@ -241,9 +241,9 @@
       "default": ""
     },
     {
-      "name": "GeminiAPIKey",
-      "title": "Google Gemini API Key",
-      "description": "Optional. Only used if Gemini provider is selected.",
+      "name": "GeminiAPIKeys",
+      "title": "Google Gemini API Keys",
+      "description": "Optional. Only used if Gemini provider is selected. Multiple keys are supported - separate them with commas.",
       "required": false,
       "type": "password",
       "default": ""

--- a/package.json
+++ b/package.json
@@ -207,6 +207,10 @@
         {
           "title": "Replicate (mixtral-8x7b)",
           "value": "ReplicateMixtral_8x7B"
+        },
+        {
+          "title": "Google Gemini (requires API Key)",
+          "value": "GoogleGemini"
         }
       ],
       "default": "GPT35"
@@ -232,6 +236,14 @@
       "name": "TavilyAPIKeys",
       "title": "Tavily API Keys",
       "description": "Optional. Only used if Web Search is enabled. Multiple keys are supported - separate them with commas.",
+      "required": false,
+      "type": "password",
+      "default": ""
+    },
+    {
+      "name": "GeminiAPIKey",
+      "title": "Google Gemini API Key",
+      "description": "Optional. Only used if Gemini model is selected.",
       "required": false,
       "type": "password",
       "default": ""
@@ -279,6 +291,7 @@
     "@raycast/api": "^1.62.0",
     "@raycast/utils": "^1.9.0",
     "g4f": "^1.4.2",
+    "gemini-ai": "^1.1.0",
     "node-fetch-polyfill": "^2.0.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
     {
       "name": "GeminiAPIKey",
       "title": "Google Gemini API Key",
-      "description": "Optional. Only used if Gemini model is selected.",
+      "description": "Optional. Only used if Gemini provider is selected.",
       "required": false,
       "type": "password",
       "default": ""

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -13,7 +13,7 @@ import {
   useNavigation,
 } from "@raycast/api";
 import { useEffect, useState } from "react";
-import { defaultProvider, formatResponse, getChatResponse, getChatResponseSync, providers } from "./api/gpt";
+import { default_provider_string, formatResponse, getChatResponse, getChatResponseSync, providers } from "./api/gpt";
 import { formatDate, formatChatToPrompt, formatChatToGPT } from "./api/helper";
 
 // Web search module
@@ -66,7 +66,7 @@ export default function Chat({ launchContext }) {
     name = "New Chat",
     creationDate = new Date(),
     id = new Date().getTime().toString(), // toString() is important because Raycast expects a string for value
-    provider = defaultProvider(),
+    provider = default_provider_string(),
     systemPrompt = "",
     messages = [],
   }) => {
@@ -300,7 +300,7 @@ export default function Chat({ launchContext }) {
       >
         <Form.TextArea id="chatText" title="Chat Transcript" />
         <Form.Description title="GPT Model" text="The provider and model used for this chat." />
-        <Form.Dropdown id="provider" defaultValue={defaultProvider()}>
+        <Form.Dropdown id="provider" defaultValue={default_provider_string()}>
           {ChatProvidersReact}
         </Form.Dropdown>
       </Form>

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -13,13 +13,7 @@ import {
   useNavigation,
 } from "@raycast/api";
 import { useEffect, useState } from "react";
-import {
-  defaultProvider,
-  formatResponse,
-  getChatResponse,
-  getChatResponseSync,
-  providers,
-} from "./api/gpt";
+import { defaultProvider, formatResponse, getChatResponse, getChatResponseSync, providers } from "./api/gpt";
 import { formatDate, formatChatToPrompt, formatChatToGPT } from "./api/helper";
 
 // Web search module

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -177,14 +177,13 @@ export default function Chat({ launchContext }) {
       chars = response.length;
       charPerSec = (chars / elapsed).toFixed(1);
     } else {
-      let r = await getChatResponse(currentChat, query);
       let loadingToast = await toast(Toast.Style.Animated, "Response Loading");
       generationStatus = { stop: false, loading: true };
       let i = 0;
 
-      for await (const chunk of await processChunks(r, provider, get_status)) {
+      const handler = async (new_message) => {
         i++;
-        response = chunk;
+        response = new_message;
         response = formatResponse(response, provider);
         await setCurrentChatData(chatData, setChatData, messageID, null, response);
 
@@ -206,7 +205,9 @@ export default function Chat({ launchContext }) {
         chars = response.length;
         charPerSec = (chars / elapsed).toFixed(1);
         loadingToast.message = `${chars} chars (${charPerSec} / sec) | ${elapsed.toFixed(1)} sec`;
-      }
+      };
+
+      await getChatResponse(currentChat, query, handler, get_status);
     }
 
     // Web Search functionality

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -18,7 +18,6 @@ import {
   formatResponse,
   getChatResponse,
   getChatResponseSync,
-  processChunks,
   providers,
 } from "./api/gpt";
 import { formatDate, formatChatToPrompt, formatChatToGPT } from "./api/helper";

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -41,6 +41,7 @@ const chat_providers = [
   ["Replicate (meta-llama-3-8b)", "ReplicateLlama3_8B"],
   ["Replicate (meta-llama-3-70b)", "ReplicateLlama3_70B"],
   ["Replicate (mixtral-8x7b)", "ReplicateMixtral_8x7B"],
+  ["Google Gemini (requires API Key)", "GoogleGemini"],
 ];
 
 const ChatProvidersReact = chat_providers.map((x) => {

--- a/src/api/Providers/google_gemini.jsx
+++ b/src/api/Providers/google_gemini.jsx
@@ -4,7 +4,7 @@ import fetch from "node-fetch-polyfill";
 
 export const GeminiProvider = "GeminiProvider";
 
-export const getGoogleGeminiResponse = async (chat, options, stream_update, max_retries = 2) => {
+export const getGoogleGeminiResponse = async (chat, options, stream_update, max_retries = 3) => {
   let APIKeysStr = getPreferenceValues()["GeminiAPIKeys"];
   let APIKeys = APIKeysStr.split(",").map((x) => x.trim());
   let formattedChat = GeminiFormatChat(chat);

--- a/src/api/Providers/google_gemini.jsx
+++ b/src/api/Providers/google_gemini.jsx
@@ -1,0 +1,43 @@
+import Gemini from "gemini-ai";
+import { getPreferenceValues } from "@raycast/api";
+import fetch from "node-fetch-polyfill";
+
+export const GeminiProvider = "GeminiProvider";
+
+export const getGoogleGeminiResponse = async (chat) => {
+  const APIKey = getPreferenceValues()["GeminiAPIKey"];
+  const googleGemini = new Gemini(APIKey, { fetch: fetch });
+  let formattedChat = GeminiFormatChat(chat);
+
+  // Send message
+  let query = chat[chat.length - 1].content;
+  const geminiChat = googleGemini.createChat({
+    model: "gemini-pro",
+    messages: formattedChat,
+  });
+  let response = await geminiChat.ask(query);
+  return response;
+};
+
+// Reformat chat to be in google gemini format
+export const GeminiFormatChat = (chat) => {
+  let formattedChat = [];
+
+  // Discard system prompt as it is not supported by the API
+  if (chat.length >= 2 && chat[0].role === "user" && chat[1].role === "user") {
+    chat.shift(); // remove first user message (system prompt)
+  }
+
+  let currentPair = [];
+  for (let i = 0; i < chat.length; i++) {
+    const message = chat[i];
+    if (currentPair.length === 0) {
+      currentPair.push(message.content);
+    } else {
+      currentPair.push(message.content);
+      formattedChat.push(currentPair);
+      currentPair = [];
+    }
+  }
+  return formattedChat;
+};

--- a/src/api/Providers/google_gemini.jsx
+++ b/src/api/Providers/google_gemini.jsx
@@ -15,6 +15,7 @@ export const getGoogleGeminiResponse = async (chat, options, stream_update, max_
     model: options.model,
     messages: formattedChat,
     maxOutputTokens: 8192, // accurate as of 2024-05-31, for gemini-1.5-flash-latest
+    temperature: options.temperature || 0.7,
   });
 
   // Send message

--- a/src/api/Providers/google_gemini.jsx
+++ b/src/api/Providers/google_gemini.jsx
@@ -4,20 +4,40 @@ import fetch from "node-fetch-polyfill";
 
 export const GeminiProvider = "GeminiProvider";
 
-export const getGoogleGeminiResponse = async (chat, options) => {
+export const getGoogleGeminiResponse = async (chat, options, stream_update, max_retries = 5) => {
   const APIKey = getPreferenceValues()["GeminiAPIKey"];
   const googleGemini = new Gemini(APIKey, { fetch: fetch });
   let formattedChat = GeminiFormatChat(chat);
 
-  // Send message
+  // Create chat
   let query = chat[chat.length - 1].content;
   const geminiChat = googleGemini.createChat({
     model: options.model,
     messages: formattedChat,
     maxOutputTokens: 8192, // accurate as of 2024-05-31, for gemini-1.5-flash-latest
   });
-  let response = await geminiChat.ask(query);
-  return response;
+
+  // Send message
+  try {
+    let response = "";
+    if (stream_update) {
+      const handler = (chunk) => {
+        response += chunk;
+        stream_update(response);
+      };
+      await geminiChat.ask(query, { stream: handler });
+    } else {
+      response = await geminiChat.ask(query);
+      return response;
+    }
+  } catch (e) {
+    if (max_retries > 0) {
+      console.log(e, "Retrying...");
+      return await getGoogleGeminiResponse(chat, options, stream_update, max_retries - 1);
+    } else {
+      throw e;
+    }
+  }
 };
 
 // Reformat chat to be in google gemini format

--- a/src/api/Providers/google_gemini.jsx
+++ b/src/api/Providers/google_gemini.jsx
@@ -4,7 +4,7 @@ import fetch from "node-fetch-polyfill";
 
 export const GeminiProvider = "GeminiProvider";
 
-export const getGoogleGeminiResponse = async (chat) => {
+export const getGoogleGeminiResponse = async (chat, options) => {
   const APIKey = getPreferenceValues()["GeminiAPIKey"];
   const googleGemini = new Gemini(APIKey, { fetch: fetch });
   let formattedChat = GeminiFormatChat(chat);
@@ -12,8 +12,9 @@ export const getGoogleGeminiResponse = async (chat) => {
   // Send message
   let query = chat[chat.length - 1].content;
   const geminiChat = googleGemini.createChat({
-    model: "gemini-pro",
+    model: options.model,
     messages: formattedChat,
+    maxOutputTokens: 8192, // accurate as of 2024-05-31, for gemini-1.5-flash-latest
   });
   let response = await geminiChat.ask(query);
   return response;

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -55,7 +55,7 @@ export const providers = {
   ReplicateLlama3_8B: [ReplicateProvider, "meta/meta-llama-3-8b-instruct", true],
   ReplicateLlama3_70B: [ReplicateProvider, "meta/meta-llama-3-70b-instruct", true],
   ReplicateMixtral_8x7B: [ReplicateProvider, "mistralai/mixtral-8x7b-instruct-v0.1", true],
-  GoogleGemini: [GeminiProvider, "", false],
+  GoogleGemini: [GeminiProvider, "gemini-1.5-flash-latest", false],
 };
 
 // Additional options
@@ -387,7 +387,7 @@ export const chatCompletion = async (chat, options) => {
     response = await getReplicateResponse(chat, options);
   } else if (provider === GeminiProvider) {
     // Google Gemini
-    response = await getGoogleGeminiResponse(chat);
+    response = await getGoogleGeminiResponse(chat, options);
   } else {
     // GPT
     response = await g4f.chatCompletion(chat, options);

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -72,7 +72,7 @@ export const provider_options = (provider) => {
 // providers that handle the stream update in a custom way (see chatCompletion function)
 const custom_stream_handled_providers = [GeminiProvider];
 
-export const defaultProvider = () => {
+export const default_provider_string = () => {
   return getPreferenceValues()["gptProvider"];
 };
 
@@ -375,8 +375,11 @@ export default (
 // otherwise, this function returns an async generator (if stream = true) or a string (if stream = false)
 // if status is passed, we will stop generating when status() is true
 export const chatCompletion = async (chat, options, stream_update = null, status = null) => {
-  let response;
   const provider = options.provider;
+  // additional options
+  options = { ...options, ...provider_options(provider) };
+
+  let response;
   if (provider === NexraProvider) {
     // Nexra
     response = await getNexraResponse(chat, options);
@@ -422,7 +425,7 @@ export const getChatResponse = async (currentChat, query = null, stream_update =
   let chat = formatChatToGPT(currentChat, query);
 
   // load provider and model
-  if (!currentChat.provider) currentChat.provider = defaultProvider();
+  if (!currentChat.provider) currentChat.provider = default_provider_string();
   const providerString = currentChat.provider;
   const [provider, model, stream] = providers[providerString];
   let options = {
@@ -430,7 +433,6 @@ export const getChatResponse = async (currentChat, query = null, stream_update =
     model: model,
     stream: stream,
   };
-
   // additional options
   options = { ...options, ...provider_options(provider) };
 

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -36,6 +36,9 @@ import { BlackboxProvider, getBlackboxResponse } from "./Providers/blackbox";
 // Replicate module
 import { ReplicateProvider, getReplicateResponse } from "./Providers/replicate";
 
+// Google Gemini module
+import { GeminiProvider, getGoogleGeminiResponse } from "./Providers/google_gemini";
+
 // Providers
 // [Provider, Model, Stream]
 export const providers = {
@@ -52,6 +55,7 @@ export const providers = {
   ReplicateLlama3_8B: [ReplicateProvider, "meta/meta-llama-3-8b-instruct", true],
   ReplicateLlama3_70B: [ReplicateProvider, "meta/meta-llama-3-70b-instruct", true],
   ReplicateMixtral_8x7B: [ReplicateProvider, "mistralai/mixtral-8x7b-instruct-v0.1", true],
+  GoogleGemini: [GeminiProvider, "", false],
 };
 
 // Additional options
@@ -381,6 +385,9 @@ export const chatCompletion = async (chat, options) => {
   } else if (provider === ReplicateProvider) {
     // Replicate
     response = await getReplicateResponse(chat, options);
+  } else if (provider === GeminiProvider) {
+    // Google Gemini
+    response = await getGoogleGeminiResponse(chat);
   } else {
     // GPT
     response = await g4f.chatCompletion(chat, options);


### PR DESCRIPTION
The removal of Gemini was probably not the best idea... >:)
1. Google API Keys are completely free and the rate limits are pretty generous: https://ai.google.dev/gemini-api/docs/models/gemini
2. Gemini models (specifically gemini-1.5-flash) are pretty good

### huge update: addition of streaming
Part of the reason why Gemini was removed is because I didn't write streaming support for it, and that made it pretty subpar. But now I have also added **streaming support** for it!! To make this possible, I refactored a sizable chunk of code. There is some added complexity, but hopefully it's organised well enough. I've also tried my best to ensure that nothing should break when it comes to backward compatibility.

We now also support multiple Gemini API Keys in the preferences, so the rate limit is effectively increased.