### PR TITLE
Migrate to node-fetch, update gemini-ai to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "@raycast/api": "^1.62.0",
         "@raycast/utils": "^1.9.0",
         "g4f": "^1.4.2",
-        "gemini-ai": "^1.1.0",
+        "gemini-ai": "^2.1.0",
+        "node-fetch": "^3.3.2",
         "node-fetch-polyfill": "^2.0.6"
       },
       "devDependencies": {
@@ -330,6 +331,11 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.3.tgz",
       "integrity": "sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg==",
       "dev": true
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -777,6 +783,25 @@
         "node-fetch": "^2.6.12"
       }
     },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -795,6 +820,14 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -1181,6 +1214,36 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -1210,6 +1273,22 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.0.0.tgz",
+      "integrity": "sha512-s7cxa7/leUWLiXO78DVVfBVse+milos9FitauDLG1pI7lNaJ2+5lzPnr2N24ym+84HVwJL6hVuGfgVE+ALvU8Q==",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.2",
+        "strtok3": "^7.0.0",
+        "token-types": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/fill-range": {
@@ -1287,6 +1366,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1310,9 +1400,13 @@
       }
     },
     "node_modules/gemini-ai": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gemini-ai/-/gemini-ai-1.1.0.tgz",
-      "integrity": "sha512-T9dU6Nz+Y0q/7QEfFEtRxVUcg+Kq3HHY//4tVO+NsWJMXufQfREWFyeqbUcogSZVYxZBxDEdUl538NECeEFeeg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/gemini-ai/-/gemini-ai-2.1.0.tgz",
+      "integrity": "sha512-FCRhM6sMIaOkyqIBBLKs0B2Lc6yGmbpPcAI5iH6IY0bw7DhBVtGKEYTcr3bg39r1arfk66sqQ42uANUM4BICIw==",
+      "dependencies": {
+        "file-type": "^19.0.0",
+        "undici": "^6.18.1"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -1412,6 +1506,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -1459,8 +1572,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -1711,23 +1823,39 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-fetch-polyfill": {
@@ -1872,6 +2000,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
+      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
@@ -1989,6 +2129,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -2066,6 +2234,25 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -2238,6 +2425,14 @@
         "stream-chain": "^2.2.5"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -2282,6 +2477,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
+      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/supports-color": {
@@ -2361,6 +2572,22 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/token-types": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -2430,6 +2657,14 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.18.2.tgz",
+      "integrity": "sha512-o/MQLTwRm9IVhOqhZ0NQ9oXax1ygPjw6Vs+Vq/4QRjbOAC3B1GCHy7TYxxbExKlb7bzDRzt9vBWU6BDz0RFfYg==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -2443,6 +2678,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/v8-compile-cache": {
       "version": "2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
         "@raycast/utils": "^1.9.0",
         "g4f": "^1.4.2",
         "gemini-ai": "^2.1.0",
-        "node-fetch": "^3.3.2",
-        "node-fetch-polyfill": "^2.0.6"
+        "node-fetch": "^3.3.2"
       },
       "devDependencies": {
         "@raycast/eslint-config": "1.0.5",
@@ -902,6 +901,8 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -1499,6 +1500,8 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -1616,14 +1619,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/isexe": {
@@ -1856,25 +1851,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/node-fetch-polyfill": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-fetch-polyfill/-/node-fetch-polyfill-2.0.6.tgz",
-      "integrity": "sha512-HjsTTwx8rCqE6cHc3Y55MeimyPXAA45Kah3WutaPWohMvdtpvzOL9LF1ikwPqZL9iej+yOxULRBRQ/7YdZ2+kQ==",
-      "dependencies": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1",
-        "node-web-streams": "^0.2.1"
-      }
-    },
-    "node_modules/node-web-streams": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/node-web-streams/-/node-web-streams-0.2.2.tgz",
-      "integrity": "sha512-TKWGEUb0AgDA+8+YFDYms2fgsTK87etvMpjJW9qdieXQwcn8IgIFHL2Xohorw7c19TP3dC+Ttur+oO7/c9h6vg==",
-      "dependencies": {
-        "is-stream": "^1.1.0",
-        "web-streams-polyfill": "git://github.com/gwicke/web-streams-polyfill#spec_performance_improvements"
       }
     },
     "node_modules/object-hash": {
@@ -2257,7 +2233,9 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.6.2",
@@ -2689,10 +2667,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
       "integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==",
       "dev": true
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "1.2.2",
-      "resolved": "git+ssh://git@github.com/gwicke/web-streams-polyfill.git#42c488428adea1dc0c0245014e4896ad456b1ded"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -292,8 +292,7 @@
     "@raycast/utils": "^1.9.0",
     "g4f": "^1.4.2",
     "gemini-ai": "^2.1.0",
-    "node-fetch": "^3.3.2",
-    "node-fetch-polyfill": "^2.0.6"
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "@raycast/eslint-config": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -291,7 +291,8 @@
     "@raycast/api": "^1.62.0",
     "@raycast/utils": "^1.9.0",
     "g4f": "^1.4.2",
-    "gemini-ai": "^1.1.0",
+    "gemini-ai": "^2.1.0",
+    "node-fetch": "^3.3.2",
     "node-fetch-polyfill": "^2.0.6"
   },
   "devDependencies": {

--- a/src/api/Providers/blackbox.jsx
+++ b/src/api/Providers/blackbox.jsx
@@ -1,5 +1,5 @@
 export const BlackboxProvider = "BlackboxProvider";
-import fetch from "node-fetch-polyfill";
+import fetch from "node-fetch";
 import { randomBytes, randomUUID } from "crypto";
 
 // Implementation ported from gpt4free Blackbox provider.
@@ -57,13 +57,10 @@ export const getBlackboxResponse = async function* (chat, max_retries = 5) {
       body: JSON.stringify(data),
     });
 
-    let reader = response.body.getReader();
-    let decoder = new TextDecoder();
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
+    const reader = response.body;
+    for await (let chunk of reader) {
+      chunk = chunk.toString();
 
-      let chunk = decoder.decode(value);
       if (chunk) {
         yield chunk;
       }

--- a/src/api/Providers/deepinfra.jsx
+++ b/src/api/Providers/deepinfra.jsx
@@ -48,7 +48,6 @@ export const getDeepInfraResponse = async function* (chat, options, max_retries 
     for await (let chunk of reader) {
       const str = chunk.toString();
 
-      // let str = decoder.decode(value);
       let lines = str.split("\n");
       for (let i = 0; i < lines.length; i++) {
         let line = lines[i];

--- a/src/api/Providers/deepinfra.jsx
+++ b/src/api/Providers/deepinfra.jsx
@@ -1,5 +1,5 @@
 export const DeepInfraProvider = "DeepInfraProvider";
-import fetch from "node-fetch-polyfill";
+import fetch from "node-fetch";
 
 // Implementation ported from gpt4free DeepInfra provider.
 
@@ -44,13 +44,11 @@ export const getDeepInfraResponse = async function* (chat, options, max_retries 
 
     // Implementation taken from gpt4free: g4f/Provider/needs_auth/Openai.py at async def create_async_generator()
     let first = true;
-    let reader = response.body.getReader();
-    let decoder = new TextDecoder();
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
+    const reader = response.body;
+    for await (let chunk of reader) {
+      const str = chunk.toString();
 
-      let str = decoder.decode(value);
+      // let str = decoder.decode(value);
       let lines = str.split("\n");
       for (let i = 0; i < lines.length; i++) {
         let line = lines[i];

--- a/src/api/Providers/ecosia.jsx
+++ b/src/api/Providers/ecosia.jsx
@@ -1,5 +1,5 @@
 export const EcosiaProvider = "EcosiaProvider";
-import fetch from "node-fetch-polyfill";
+import fetch from "node-fetch";
 
 const api_url = "https://api.ecosia.org/v2/chat/?sp=productivity";
 const headers = {
@@ -27,14 +27,10 @@ export const getEcosiaResponse = async function* (chat, options, max_retries = 5
       headers: headers,
       body: JSON.stringify(data),
     });
-    let reader = response.body.getReader();
-    let decoder = new TextDecoder();
+    const reader = response.body;
 
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      let chunk = decoder.decode(value);
+    for await (let chunk of reader) {
+      chunk = chunk.toString();
       if (chunk) yield chunk;
     }
   } catch (e) {

--- a/src/api/Providers/google_gemini.jsx
+++ b/src/api/Providers/google_gemini.jsx
@@ -1,6 +1,6 @@
 import Gemini from "gemini-ai";
 import { getPreferenceValues } from "@raycast/api";
-import fetch from "node-fetch-polyfill";
+import fetch from "node-fetch";
 
 export const GeminiProvider = "GeminiProvider";
 

--- a/src/api/Providers/nexra.jsx
+++ b/src/api/Providers/nexra.jsx
@@ -1,5 +1,5 @@
 export const NexraProvider = "NexraProvider";
-import fetch from "node-fetch-polyfill";
+import fetch from "node-fetch";
 
 import { removePrefix } from "../helper";
 
@@ -25,14 +25,10 @@ export const getNexraResponse = async function* (chat, options, max_retries = 5)
       body: JSON.stringify(data),
     });
 
-    const reader = response.body.getReader();
-    let decoder = new TextDecoder();
+    const reader = response.body;
 
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      let chunkStr = decoder.decode(value);
+    for await (let chunk of reader) {
+      let chunkStr = chunk.toString();
       if (!chunkStr) continue;
 
       // special fix because "\^^" is somehow added at the end of the chunk

--- a/src/api/Providers/replicate.jsx
+++ b/src/api/Providers/replicate.jsx
@@ -1,5 +1,5 @@
 export const ReplicateProvider = "ReplicateProvider";
-import fetch from "node-fetch-polyfill";
+import fetch from "node-fetch";
 import { formatChatToPrompt } from "../helper";
 
 // Implementation ported from gpt4free Replicate provider.
@@ -45,15 +45,11 @@ export const getReplicateResponse = async function* (chat, options, max_retries 
       headers: new_headers,
     });
 
-    const reader = streamResponse.body.getReader();
-    let decoder = new TextDecoder();
+    const reader = streamResponse.body;
     // eslint-disable-next-line no-constant-condition
     let curr_event = "";
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      let str = decoder.decode(value);
+    for await (let chunk of reader) {
+      let str = chunk.toString();
 
       // iterate through each line
       // implementation ported from gpt4free.

--- a/src/api/web.jsx
+++ b/src/api/web.jsx
@@ -1,5 +1,5 @@
 import { getPreferenceValues, Toast, showToast } from "@raycast/api";
-import fetch from "node-fetch-polyfill";
+import fetch from "node-fetch";
 
 export const webToken = "<|web_search|>",
   webTokenEnd = "<|end_web_search|>";


### PR DESCRIPTION
Migrate everything to node-fetch instead of node-fetch-polyfill.

Following this change we can also now update gemini-ai to v2.1.0