### PR TITLE
Add help pages for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ Let GPT automatically come up with a name for the current chat session after you
 - Thus, the extension will have to be installed from source. Regarding this, I apologize as it's indeed more complicated than downloading it from the store. I have tried my best to make the installation process quick and streamlined - please do provide feedback on whether it was simple enough!
 
 ### How does this extension compare to the paid Raycast AI? 
-- The biggest difference is probably the chat GUI. Because the developer API that Raycast provides is limited, it's not possible to replicate the Raycast AI interface exactly. The GUI used in my extension is really intuitive however, and it's also used by a lot of AI extensions on raycast.
-- Regarding the models available, and the AI quality: Raycast AI definitely has more model options - after all, money talks ;) But please rest assured that the quality of AI responses in my extension is by no means subpar! Some models available are gpt-3.5-turbo, gpt-4 (authentic!), Google Gemini, as well as large & capable open-source models like Llama3-70B and Mixtral-8x22B. If you still doubt it, I'd encourage you to the extension a try! :-) 
+- First and foremost, raycast-g4f is completely free! I strongly believe that such AI features, especially in an awesome productivity tool like Raycast, shouldn't be locked behind a paywall.
+- UI-wise, the biggest difference is probably the chat GUI. Because the developer API that Raycast provides is limited, it's not possible to replicate the Raycast AI interface exactly. The GUI used in my extension is really intuitive however, and it's also used by a lot of AI extensions on raycast.
+- Regarding the models available, and the AI quality: Raycast AI definitely has more model options - after all, money talks ;) But please rest assured that the quality of AI responses in my extension is by no means subpar! Some models available are gpt-3.5-turbo, gpt-4 (authentic!), Google Gemini, as well as large & capable open-source models like Llama3-70B and Mixtral-8x22B. If you still doubt it, I'd encourage you to give the extension a try! :-) 
 
 
 ---

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -21,6 +21,7 @@ import {
   providers_info,
 } from "./api/gpt";
 import { formatDate, formatChatToPrompt, formatChatToGPT } from "./api/helper";
+import { help_action, help_action_panel } from "./api/helpPage";
 
 // Web search module
 import { getWebResult } from "./api/web";
@@ -944,6 +945,7 @@ export default function Chat({ launchContext }) {
             style={Action.Style.Destructive}
           />
         </ActionPanel.Section>
+        {help_action("aiChat")}
       </ActionPanel>
     );
   };
@@ -1030,7 +1032,7 @@ export default function Chat({ launchContext }) {
 
   return chatData === null ? (
     <List searchText={searchText} onSearchTextChange={setSearchText}>
-      <List.EmptyView icon={Icon.SpeechBubble} title="Ask GPT Anything..." />
+      <List.EmptyView icon={Icon.SpeechBubble} title="Ask GPT Anything..." actions={help_action_panel("aiChat")} />
     </List>
   ) : (
     <List

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -17,6 +17,7 @@ import {
 import { useEffect, useState } from "react";
 
 import { formatChatToGPT } from "./helper";
+import { help_action } from "./helpPage";
 
 // G4F module
 import { G4F } from "g4f";
@@ -371,6 +372,7 @@ export default (
             }}
             shortcut={{ modifiers: ["cmd", "shift"], key: "r" }}
           />
+          {help_action()}
         </ActionPanel>
       }
       isLoading={isLoading}

--- a/src/api/helpPage.jsx
+++ b/src/api/helpPage.jsx
@@ -1,0 +1,17 @@
+import { Action, ActionPanel, Icon } from "@raycast/api";
+
+const helpPages = {
+  // paths to help pages
+  aiChat: "https://github.com/XInTheDark/raycast-g4f/wiki/Help-page:-AI-Chat",
+  customAICommands: "https://github.com/XInTheDark/raycast-g4f/wiki/Help-page:-Custom-AI-Commands",
+  default: "https://github.com/XInTheDark/raycast-g4f/blob/main/README.md",
+};
+
+export const help_action = (module_name = null) => {
+  const path = module_name && helpPages[module_name] ? helpPages[module_name] : helpPages.default;
+  return <Action.OpenInBrowser title="Help" icon={Icon.QuestionMark} url={path} />;
+};
+
+export const help_action_panel = (module_name = null) => {
+  return <ActionPanel>{help_action(module_name)}</ActionPanel>;
+};

--- a/src/customAICommands.jsx
+++ b/src/customAICommands.jsx
@@ -2,6 +2,7 @@ import { CustomCommand, getCustomCommands, setCustomCommands } from "./api/custo
 import { useEffect, useState } from "react";
 import { Form, List, Action, ActionPanel, Icon, useNavigation, confirmAlert } from "@raycast/api";
 import useGPT from "./api/gpt";
+import { help_action } from "./api/helpPage";
 
 export default function CustomAICommands() {
   let [commands, setCommands] = useState(null);
@@ -91,6 +92,7 @@ export default function CustomAICommands() {
           shortcut={{ modifiers: ["cmd", "shift"], key: "delete" }}
           style={Action.Style.Destructive}
         />
+        {help_action("customAICommands")}
       </ActionPanel>
     );
   };
@@ -120,6 +122,7 @@ export default function CustomAICommands() {
                 icon={Icon.PlusCircle}
                 target={<EditCommandForm newCommand={true} />}
               />
+              {help_action("customAICommands")}
             </ActionPanel>
           }
         />


### PR DESCRIPTION
This is accessed via the `Help` action. 
They just link to the GitHub wiki pages on this repository.