### PR TITLE
Add Storage interface for persistent storage

### DIFF
--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -7,12 +7,12 @@ import {
   getPreferenceValues,
   Icon,
   List,
-  LocalStorage,
   showToast,
   Toast,
   useNavigation,
 } from "@raycast/api";
 import { useEffect, useState } from "react";
+import { Storage } from "./api/storage";
 import {
   default_provider_string,
   formatResponse,
@@ -66,14 +66,14 @@ export default function Chat({ launchContext }) {
     return {
       currentChat: newChat.id,
       chats: [newChat],
-      lastPruneTime: new Date().getTime(),
+      lastPruneTime: Date.now(),
     };
   };
 
   let chat_data = ({
     name = "New Chat",
     creationDate = new Date(),
-    id = new Date().getTime().toString(), // toString() is important because Raycast expects a string for value
+    id = Date.now().toString(), // toString() is important because Raycast expects a string for value
     provider = default_provider_string(),
     systemPrompt = "",
     messages = [],
@@ -94,7 +94,7 @@ export default function Chat({ launchContext }) {
     prompt = "",
     answer = "",
     creationDate = new Date(),
-    id = new Date().getTime(),
+    id = Date.now(),
     finished = false,
     visible = true,
   }) => {
@@ -169,14 +169,14 @@ export default function Chat({ launchContext }) {
     let elapsed = 0.001,
       chars,
       charPerSec;
-    let start = new Date().getTime();
+    let start = Date.now();
     let response = "";
 
     if (!info.stream) {
       response = await getChatResponse(currentChat, query);
       await setCurrentChatData(chatData, setChatData, messageID, null, response);
 
-      elapsed = (new Date().getTime() - start) / 1000;
+      elapsed = (Date.now() - start) / 1000;
       chars = response.length;
       charPerSec = (chars / elapsed).toFixed(1);
     } else {
@@ -204,7 +204,7 @@ export default function Chat({ launchContext }) {
           return;
         }
 
-        elapsed = (new Date().getTime() - start) / 1000;
+        elapsed = (Date.now() - start) / 1000;
         chars = response.length;
         charPerSec = (chars / elapsed).toFixed(1);
         loadingToast.message = `${chars} chars (${charPerSec} / sec) | ${elapsed.toFixed(1)} sec`;
@@ -244,7 +244,7 @@ export default function Chat({ launchContext }) {
 
   let pruneChats = (chatData, setChatData) => {
     const lastPruneTime = chatData.lastPruneTime || 0;
-    const currentTime = new Date().getTime();
+    const currentTime = Date.now();
     if (currentTime - lastPruneTime < pruneChatsInterval) return;
 
     let pruneChatsLimit = getPreferenceValues()["inactiveDuration"];
@@ -955,37 +955,13 @@ export default function Chat({ launchContext }) {
 
   useEffect(() => {
     (async () => {
-      const storedChatData = await LocalStorage.getItem("chatData");
+      const storedChatData = await Storage.read("chatData");
       if (storedChatData) {
         let newData = JSON.parse(storedChatData);
-
-        // Legacy feature to regenerate last message, from raycast-gemini.
-        // This feature no longer works because of how we handle streaming.
-        //
-        // if (getChat(newData.currentChat, newData.chats).messages[0]?.finished === false) {
-        //   let currentChat = getChat(newData.currentChat, newData.chats);
-        //   currentChat.messages[0].answer = "";
-        //
-        //   toast(Toast.Style.Animated, "Regenerating Last Message");
-        //   await (async () => {
-        //     try {
-        //       await updateChatResponse(newData, setChatData, "");
-        //       toast(Toast.Style.Success, "Response Loaded");
-        //     } catch {
-        //       setChatData((oldData) => {
-        //         let newChatData = structuredClone(oldData);
-        //         getChat(newData.currentChat, newChatData.chats).messages.shift();
-        //         return newChatData;
-        //       });
-        //       toast(Toast.Style.Failure, "GPT cannot process this message.");
-        //     }
-        //   })();
-        // }
-
         setChatData(structuredClone(newData));
       } else {
         const newChatData = default_all_chats_data();
-        await LocalStorage.setItem("chatData", JSON.stringify(newChatData));
+        await Storage.write("chatData", JSON.stringify(newChatData));
         setChatData(newChatData);
       }
 
@@ -1014,7 +990,7 @@ export default function Chat({ launchContext }) {
   useEffect(() => {
     if (chatData) {
       (async () => {
-        await LocalStorage.setItem("chatData", JSON.stringify(chatData));
+        await Storage.write("chatData", JSON.stringify(chatData));
       })();
     }
   }, [chatData]);

--- a/src/api/customCommands.jsx
+++ b/src/api/customCommands.jsx
@@ -1,7 +1,7 @@
-import { LocalStorage } from "@raycast/api";
+import { Storage } from "./storage";
 
 export class CustomCommand {
-  constructor({ name = "", prompt = "", id = new Date().getTime().toString(), options = {} }) {
+  constructor({ name = "", prompt = "", id = Date.now().toString(), options = {} }) {
     this.name = name;
     this.prompt = prompt;
     this.id = id;
@@ -22,15 +22,10 @@ export class CustomCommand {
 }
 
 export const getCustomCommands = async () => {
-  const retrieved = await LocalStorage.getItem("customCommands");
-  if (!retrieved) {
-    await LocalStorage.setItem("customCommands", JSON.stringify([]));
-    return [];
-  } else {
-    return JSON.parse(retrieved).map((x) => new CustomCommand(x));
-  }
+  const retrieved = await Storage.read("customCommands", "[]");
+  return JSON.parse(retrieved).map((x) => new CustomCommand(x));
 };
 
 export const setCustomCommands = async (commands) => {
-  await LocalStorage.setItem("customCommands", JSON.stringify(commands));
+  if (commands) await Storage.write("customCommands", JSON.stringify(commands));
 };

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -175,13 +175,13 @@ export default (
       // generate response
       let response = "";
       let elapsed, chars, charPerSec;
-      let start = new Date().getTime();
+      let start = Date.now();
 
       if (!info.stream) {
         response = await chatCompletion(messages, options);
         setMarkdown(response);
 
-        elapsed = (new Date().getTime() - start) / 1000;
+        elapsed = (Date.now() - start) / 1000;
         chars = response.length;
         charPerSec = (chars / elapsed).toFixed(1);
       } else {
@@ -193,7 +193,7 @@ export default (
           response = formatResponse(response, info.provider);
           setMarkdown(response);
 
-          elapsed = (new Date().getTime() - start) / 1000;
+          elapsed = (Date.now() - start) / 1000;
           chars = response.length;
           charPerSec = (chars / elapsed).toFixed(1);
           loadingToast.message = `${chars} chars (${charPerSec} / sec) | ${elapsed.toFixed(1)} sec`;

--- a/src/api/storage.jsx
+++ b/src/api/storage.jsx
@@ -1,0 +1,133 @@
+// This is the Storage interface, which combines LocalStorage with more persistent file system storage.
+// We generally also keep the two versions in sync, but the sync process happens only periodically
+// and thus the file storage should not be relied upon for immediate consistency.
+// Note that persistent storage is not always the best option as file I/O is relatively expensive.
+// Thus, only use it when you really need to persist data across sessions.
+
+import { environment, LocalStorage } from "@raycast/api";
+import fs from "fs";
+
+const not_found = (x) => x === undefined || x === null;
+const found = (x) => !not_found(x);
+
+export const Storage = {
+  /// Local storage functions - these provide quicker access that is not critical to persist
+
+  // check if item exists in local storage
+  localStorage_has: async (key) => {
+    return found(await LocalStorage.getItem(key));
+  },
+
+  // write to local storage
+  // value is stored as-is, it is the user's responsibility to serialize it if needed
+  localStorage_write: async (key, value) => {
+    await LocalStorage.setItem(key, value);
+  },
+
+  // read from local storage
+  // if a default value is provided and key is not found, write the default value to local storage
+  // value is returned as-is, it is the user's responsibility to deserialize it if needed
+  localStorage_read: async (key, default_value = undefined) => {
+    const retrieved = await LocalStorage.getItem(key);
+    if (not_found(retrieved) && default_value !== undefined) {
+      await Storage.localStorage_write(key, default_value);
+      return default_value;
+    }
+    return retrieved;
+  },
+
+  /// For file storage we use a dedicated directory within the support path.
+  /// As a speedup, we store each key-value pair in a separate file.
+
+  // get file storage path for a key
+  // it is the user's responsibility to ensure that the key is a valid file name
+  fileStoragePath: (key) => {
+    return `${environment.supportPath}/storage/${key}.txt`;
+  },
+
+  // check if item exists in file storage
+  fileStorage_has: async (key) => {
+    return fs.existsSync(Storage.fileStoragePath(key));
+  },
+
+  // write to file storage
+  fileStorage_write: async (key, value) => {
+    // ensure storage directory exists
+    const dir = `${environment.supportPath}/storage`;
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir);
+    const path = Storage.fileStoragePath(key);
+    fs.writeFileSync(path, value);
+  },
+
+  // read from file storage
+  // if a default value is provided and key is not found, write the default value to file storage
+  fileStorage_read: async (key, default_value = undefined) => {
+    const path = Storage.fileStoragePath(key);
+    if (!fs.existsSync(path)) {
+      if (default_value === undefined) return undefined;
+      await Storage.fileStorage_write(key, default_value);
+      return default_value;
+    }
+    return fs.readFileSync(path, "utf8");
+  },
+
+  /// Sync functions
+  /// We carry out a sync process periodically when either read or write is called
+
+  syncInterval: 5 * 60 * 1000, // interval for syncing local and file storage (in ms)
+
+  add_to_sync_cache: async (key) => {
+    // important! the keys syncCache and lastSync should ONLY EVER be put in local storage
+    // or else it will likely cause infinite recursion in the combined read function.
+    // anyway it's useless to put them in file storage as they are only used for syncing
+    let syncCache = JSON.parse(await Storage.localStorage_read("syncCache", "{}"));
+    syncCache[key] = true;
+    await Storage.localStorage_write("syncCache", JSON.stringify(syncCache));
+  },
+
+  run_sync: async () => {
+    let lastSync = await Storage.localStorage_read("lastSync", 0);
+    if (Date.now() - lastSync < Storage.syncInterval) return;
+
+    console.log("Storage API: running sync process");
+    let syncCache = JSON.parse(await Storage.localStorage_read("syncCache", "{}"));
+    for (const key of Object.keys(syncCache)) {
+      const local = await Storage.localStorage_read(key);
+      await Storage.fileStorage_write(key, local);
+    }
+
+    // clear sync cache, reset last sync time
+    await Storage.localStorage_write("syncCache", "{}");
+    await Storage.localStorage_write("lastSync", Date.now());
+  },
+
+  // combined write function
+  // first write to local storage function only, and then add key to sync cache to add to file storage later
+  write: async (key, value) => {
+    await Storage.localStorage_write(key, value);
+    await Storage.add_to_sync_cache(key);
+    await Storage.run_sync();
+  },
+
+  // combined read function - read from local storage, fallback to file storage
+  read: async (key, default_value = undefined) => {
+    let value;
+    if (await Storage.localStorage_has(key)) {
+      value = await Storage.localStorage_read(key);
+      // note how we only sync here, as it only makes sense when we have a value in local storage
+      await Storage.add_to_sync_cache(key);
+      await Storage.run_sync();
+    } else if (await Storage.fileStorage_has(key)) {
+      console.log(`Reading key: ${key} from file storage`);
+      value = await Storage.fileStorage_read(key);
+      // write to local storage
+      await Storage.localStorage_write(key, value);
+    } else {
+      console.log(`Key: ${key} not found, returning default value`);
+      value = default_value;
+      // write to both local and file storage
+      if (value !== undefined) await Storage.write(key, value);
+    }
+    return value;
+  },
+};

--- a/src/genImage.jsx
+++ b/src/genImage.jsx
@@ -217,7 +217,7 @@ export default function genImage() {
             setChatData((x) => {
               let newChatData = structuredClone(x);
               let currentChat = getChat(chatData.currentChat, newChatData.chats);
-              let messageID = new Date().getTime();
+              let messageID = Date.now();
 
               currentChat.messages.unshift({
                 prompt: query,


### PR DESCRIPTION
Adds the new combined read() and write() functions while still keeping support for LocalStorage and File storage APIs respectively. When reading, first read from local storage as usual, but if the data is not found, then fallback to file storage. Similarly, when writing, we write to local storage as usual, but sync the data from local storage to file storage once every 5 minutes (maximum).

TLDR: This commit allows for data to be saved persistently even after local storage is cleared.

Detailed documentation in storage.jsx.

Also includes:
- change all occurrences of `new Date().getTime()` to `Date.now()`