### PR TITLE
Fix double response generation in AI commands

### DIFF
--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -663,12 +663,12 @@ export default function Chat({ launchContext }) {
         />
         <Action.Push icon={Icon.BlankDocument} title="Compose Message" target={<ComposeMessageComponent />} />
         <ActionPanel.Section title="Current Chat">
-          {generationStatus.loading && (
+          {!generationStatus.stop && (
             <Action
               title="Stop Response"
               icon={Icon.Pause}
               onAction={() => {
-                generationStatus = { stop: true, loading: false };
+                generationStatus.stop = true;
               }}
               shortcut={{ modifiers: ["cmd", "shift", "opt"], key: "/" }}
             />

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -179,6 +179,10 @@ export default (
   // We work around this by preventing any generation when the generationStatus.loading flag is set to true.
   useEffect(() => {
     (async () => {
+      // This is also part of the workaround for the double rendering issue. If we are currently generating a response
+      // then we should not attempt to generate another response, or set the page to a Form.
+      if (generationStatus.loading) return;
+
       if (useSelected) {
         let systemPrompt = (context ? `${context}\n\n` : "") + (argQuery ? argQuery : "");
 


### PR DESCRIPTION
For unknown reasons, the useEffect hook in gpt.jsx is rendered twice, both at the same time.
This results in getResponse() being called twice whenever a command is called directly (i.e. the form is not shown).
This problem has always been present, and it's also present in the original raycast-gemini.

The problem is reproducible by launching any AI command **with all arguments passed directly from the root search**. The displayed text will switch back and forth between two different generating responses. The problem is especially noticeable when using a provider that streams chunks quickly. 

We work around this by preventing any generation when the generationStatus.loading flag is set to true.