### PR TITLE
First step to removing g4f-ts package

### DIFF
--- a/Privacy.md
+++ b/Privacy.md
@@ -26,7 +26,7 @@ By using the Extension, you agree to this Policy.
 
 | Provider      | Link to Terms                                                                                                                                                |
 |---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| GPT, Bing     | [https://nexra.aryahcr.cc/terms](https://nexra.aryahcr.cc/terms)                                                                                             |
+| GPT           | [https://nexra.aryahcr.cc/terms](https://nexra.aryahcr.cc/terms)                                                                                             |
 | DeepInfra     | [https://deepinfra.com/terms](https://deepinfra.com/terms)                                                                                                   |
 | Blackbox      | [https://www.useblackbox.io/terms](https://www.useblackbox.io/terms), [https://www.useblackbox.io/privacy](https://www.useblackbox.io/privacy)               |
 | Ecosia        | [https://www.ecosia.org/terms-of-service](https://www.ecosia.org/terms-of-service), [https://www.ecosia.org/privacy](https://www.ecosia.org/privacy)         |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ updating manually also allows you to fetch and view the latest changes to the so
 |--------------------|-------------------------|-----------|---------------------------|-----------|---------------------------------------------------------------------------------------------|
 | GPT                | gpt-3.5-turbo (default) | ✅         | ![Active][active-badge]   | Fast      | 7.5/10, the most reliable and decently performing model but there are some stronger models. |
 | GPT                | gpt-4                   | ❌         | ![Active][active-badge]   | Medium    | 6.5/10, no streaming support but otherwise a great model.                                   |
-| Bing               | gpt-4                   | ✅         | ![Unknown][unknown-badge] | Slow      | 6/10, generation speed is likely quite slow but comes with built-in web search ability.     |
 | DeepInfra          | Mixtral-8x22B           | ✅         | ![Active][active-badge]   | Fast      | 7.5/10, capable model for general use.                                                      |
 | DeepInfra          | Qwen2-72B               | ✅         | ![Active][active-badge]   | Fast      | 7.5/10                                                                                      |
 | DeepInfra          | meta-llama-3-70b        | ✅         | ![Active][active-badge]   | Medium    | 7/10                                                                                        |

--- a/package.json
+++ b/package.json
@@ -202,10 +202,6 @@
           "value": "GPT4"
         },
         {
-          "title": "Bing (gpt-4)",
-          "value": "Bing"
-        },
-        {
           "title": "DeepInfra (Mixtral-8x22B)",
           "value": "DeepInfraMixtral_8x22B"
         },

--- a/src/api/Providers/g4f.jsx
+++ b/src/api/Providers/g4f.jsx
@@ -4,7 +4,6 @@ import { messages_to_json } from "../../classes/message";
 
 export const G4FProvider = {
   GPT: g4f.providers.GPT,
-  Bing: g4f.providers.Bing,
 };
 
 export const getG4FResponse = async (chat, options) => {

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -483,11 +483,6 @@ export const formatResponse = (response, provider = null) => {
   const is_code = response.includes("```");
 
   if (provider === providers.G4FProvider || provider === providers.NexraProvider || !is_code) {
-    // note: since the class rewrite, the first condition is actually flawed,
-    // because we include both G4FProvider.GPT and G4FProvider.Bing, even though
-    // only Bing is supposed to be included. However, this is not a problem because
-    // the response is never poorly formatted for GPT anyway.
-
     // replace escape characters: \n with a real newline, \t with a real tab, etc.
     response = response.replace(/\\n/g, "\n");
     response = response.replace(/\\t/g, "\t");
@@ -506,11 +501,6 @@ export const formatResponse = (response, provider = null) => {
     response = response.replace(/<\/sup>/g, "");
   }
 
-  // Bing: replace [^x> with a space where x is any string from 1 to 5 characters
-  if (provider === providers.G4FProvider) {
-    response = response.replace(/\[\^.{1,5}>/g, " ");
-  }
-
   if (provider === providers.BlackboxProvider) {
     // replace only once
     // example: remove $@$v=v1.13$@$ or $@$v=undefined%@$
@@ -526,20 +516,8 @@ export const formatResponse = (response, provider = null) => {
 
 // yield chunks incrementally from a response.
 export const processChunksIncrementalAsync = async function* (response, provider) {
-  if (provider === providers.G4FProvider) {
-    let prevChunk = "";
-    // For Bing, we must not return the last chunk
-    for await (const chunk of G4F.chunkProcessor(response)) {
-      yield prevChunk;
-      prevChunk = chunk;
-    }
-  } else if ([].includes(provider)) {
-    // nothing here currently.
-    yield* G4F.chunkProcessor(response);
-  } else {
-    // default case. response must be an async generator.
-    yield* response;
-  }
+  // default case. response must be an async generator.
+  yield* response;
 };
 
 export const processChunksIncremental = async function* (response, provider, status = null) {

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -21,7 +21,6 @@ import { autoCheckForUpdates } from "../helpers/update";
 import { Message, pairs_to_messages } from "../classes/message";
 
 import * as providers from "./providers";
-import { G4F } from "g4f";
 
 let generationStatus = { stop: false, loading: false };
 let get_status = () => generationStatus.stop;
@@ -425,9 +424,6 @@ export const chatCompletion = async (chat, options, stream_update = null, status
   } else if (provider === providers.GeminiProvider) {
     // Google Gemini
     response = await providers.getGoogleGeminiResponse(chat, options, stream_update);
-  } else if (provider === providers.G4FProvider) {
-    // G4F
-    response = await providers.getG4FResponse(chat, options);
   } else if (provider === providers.G4FLocalProvider) {
     // G4F Local
     response = await providers.getG4FLocalResponse(chat, options);
@@ -482,7 +478,7 @@ export const getChatResponseSync = async (currentChat, query = null) => {
 export const formatResponse = (response, provider = null) => {
   const is_code = response.includes("```");
 
-  if (provider === providers.G4FProvider || provider === providers.NexraProvider || !is_code) {
+  if (provider === providers.NexraProvider || !is_code) {
     // replace escape characters: \n with a real newline, \t with a real tab, etc.
     response = response.replace(/\\n/g, "\n");
     response = response.replace(/\\t/g, "\t");

--- a/src/api/providers.jsx
+++ b/src/api/providers.jsx
@@ -43,7 +43,6 @@ export { G4FLocalProvider, getG4FLocalResponse };
 export const providers_info = {
   GPT35: { provider: NexraProvider, model: "chatgpt", stream: true },
   GPT4: { provider: G4FProvider, model: "gpt-4-32k", stream: false, g4f_provider: G4FProvider.GPT },
-  Bing: { provider: G4FProvider, model: "gpt-4", stream: true, g4f_provider: G4FProvider.Bing },
   DeepInfraMixtral_8x22B: { provider: DeepInfraProvider, model: "mistralai/Mixtral-8x22B-Instruct-v0.1", stream: true },
   DeepInfraQwen2_72B: { provider: DeepInfraProvider, model: "Qwen/Qwen2-72B-Instruct", stream: true },
   DeepInfraMistral_7B: { provider: DeepInfraProvider, model: "mistralai/Mistral-7B-Instruct-v0.3", stream: true },
@@ -63,7 +62,6 @@ export const providers_info = {
 export const chat_providers = [
   ["ChatGPT (gpt-3.5-turbo)", "GPT35"],
   ["ChatGPT (gpt-4-32k)", "GPT4"],
-  ["Bing (gpt-4)", "Bing"],
   ["DeepInfra (Mixtral-8x22B)", "DeepInfraMixtral_8x22B"],
   ["DeepInfra (Qwen2-72B)", "DeepInfraQwen2_72B"],
   ["DeepInfra (Mistral-7B)", "DeepInfraMistral_7B"],

--- a/src/api/providers.jsx
+++ b/src/api/providers.jsx
@@ -5,10 +5,6 @@
 import { Form, getPreferenceValues } from "@raycast/api";
 
 /// Provider modules
-// G4F module
-import { G4FProvider, getG4FResponse } from "./Providers/g4f";
-export { G4FProvider, getG4FResponse };
-
 // Nexra module
 import { NexraProvider, getNexraResponse } from "./Providers/nexra";
 export { NexraProvider, getNexraResponse };
@@ -42,7 +38,7 @@ export { G4FLocalProvider, getG4FLocalResponse };
 // prettier-ignore
 export const providers_info = {
   GPT35: { provider: NexraProvider, model: "chatgpt", stream: true },
-  GPT4: { provider: G4FProvider, model: "gpt-4-32k", stream: false, g4f_provider: G4FProvider.GPT },
+  GPT4: { provider: NexraProvider, model: "gpt-4-32k", stream: false },
   DeepInfraMixtral_8x22B: { provider: DeepInfraProvider, model: "mistralai/Mixtral-8x22B-Instruct-v0.1", stream: true },
   DeepInfraQwen2_72B: { provider: DeepInfraProvider, model: "Qwen/Qwen2-72B-Instruct", stream: true },
   DeepInfraMistral_7B: { provider: DeepInfraProvider, model: "mistralai/Mistral-7B-Instruct-v0.3", stream: true },


### PR DESCRIPTION
Removed the inactive Bing provider.
Removed the dependency when generating text completions for `gpt-4-32k` model. We now call the Nexra API endpoint directly.

This means that we only use g4f-ts for image generation now.