### PR TITLE
Automatic model detection for Google Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,26 +54,26 @@ updating manually also allows you to fetch and view the latest changes to the so
 
 ## Providers & Models
 
-| Provider           | Model                   | Streaming | Status                    | Speed     | Rating and remarks by extension author                                                      |
-|--------------------|-------------------------|-----------|---------------------------|-----------|---------------------------------------------------------------------------------------------|
-| GPT                | gpt-3.5-turbo (default) | ✅         | ![Active][active-badge]   | Fast      | 7.5/10, the most reliable and decently performing model but there are some stronger models. |
-| GPT                | gpt-4                   | ❌         | ![Active][active-badge]   | Medium    | 6.5/10, no streaming support but otherwise a great model.                                   |
-| DeepInfra          | Mixtral-8x22B           | ✅         | ![Active][active-badge]   | Fast      | 7.5/10, capable model for general use.                                                      |
-| DeepInfra          | Mixtral-8x7B            | ✅         | ![Active][active-badge]   | Very fast | 7.5/10                                                                                      |
-| DeepInfra          | Qwen2-72B               | ✅         | ![Active][active-badge]   | Medium    | 7/10                                                                                        |
-| DeepInfra          | Mistral-7B              | ✅         | ![Active][active-badge]   | Very fast | 6.5/10                                                                                      |
-| DeepInfra          | openchat-3.6-8b         | ✅         | ![Active][active-badge]   | Very fast | 7/10                                                                                        |
-| DeepInfra          | meta-llama-3-70b        | ✅         | ![Active][active-badge]   | Medium    | 7/10                                                                                        |
-| DeepInfra          | meta-llama-3-8b         | ✅         | ![Active][active-badge]   | Very fast | 6/10                                                                                        |
-| DeepInfra          | gemma-2-27b             | ✅         | ![Active][active-badge]   | Very fast | 6.5/10                                                                                      |
-| DeepInfra          | WizardLM-2-8x22B        | ✅         | ![Unknown][unknown-badge] | Medium    | 7/10                                                                                        |
-| Blackbox           | custom model            | ✅         | ![Active][active-badge]   | Very fast | 6.5/10, very fast generation with built-in web search ability, but is optimized for coding. |
-| Ecosia             | gpt-3.5-turbo           | ✅         | ![Active][active-badge]   | Very fast | 7.5/10, near instant responses with a recent model.                                         |
-| Replicate          | mixtral-8x7b            | ✅         | ![Active][active-badge]   | Medium    | ?/10                                                                                        |
-| Replicate          | meta-llama-3-70b        | ✅         | ![Unknown][unknown-badge] | Medium    | ?/10                                                                                        |
-| Replicate          | meta-llama-3-8b         | ✅         | ![Active][active-badge]   | Fast      | ?/10                                                                                        |
-| Google Gemini      | gemini-1.5-flash-latest | ✅         | ![Active][active-badge]   | Very fast | 8/10, very good overall model but requires an API Key. (It's *free*, see the section below) |
-| GPT4Free Local API | -                       | ✅         | ![Active][active-badge]   | -         | allows access to a large variety of providers. [read more][g4f-api-help]                    |
+| Provider           | Model                                     | Streaming | Status                    | Speed     | Rating and remarks by extension author                                                      |
+|--------------------|-------------------------------------------|-----------|---------------------------|-----------|---------------------------------------------------------------------------------------------|
+| GPT                | gpt-3.5-turbo (default)                   | ✅         | ![Active][active-badge]   | Fast      | 7.5/10, the most reliable and decently performing model but there are some stronger models. |
+| GPT                | gpt-4                                     | ❌         | ![Active][active-badge]   | Medium    | 6.5/10, no streaming support but otherwise a great model.                                   |
+| DeepInfra          | Mixtral-8x22B                             | ✅         | ![Active][active-badge]   | Fast      | 7.5/10, capable model for general use.                                                      |
+| DeepInfra          | Mixtral-8x7B                              | ✅         | ![Active][active-badge]   | Very fast | 7.5/10                                                                                      |
+| DeepInfra          | Qwen2-72B                                 | ✅         | ![Active][active-badge]   | Medium    | 7/10                                                                                        |
+| DeepInfra          | Mistral-7B                                | ✅         | ![Active][active-badge]   | Very fast | 6.5/10                                                                                      |
+| DeepInfra          | openchat-3.6-8b                           | ✅         | ![Active][active-badge]   | Very fast | 7/10                                                                                        |
+| DeepInfra          | meta-llama-3-70b                          | ✅         | ![Active][active-badge]   | Medium    | 7/10                                                                                        |
+| DeepInfra          | meta-llama-3-8b                           | ✅         | ![Active][active-badge]   | Very fast | 6/10                                                                                        |
+| DeepInfra          | gemma-2-27b                               | ✅         | ![Active][active-badge]   | Very fast | 6.5/10                                                                                      |
+| DeepInfra          | WizardLM-2-8x22B                          | ✅         | ![Unknown][unknown-badge] | Medium    | 7/10                                                                                        |
+| Blackbox           | custom model                              | ✅         | ![Active][active-badge]   | Very fast | 6.5/10, very fast generation with built-in web search ability, but is optimized for coding. |
+| Ecosia             | gpt-3.5-turbo                             | ✅         | ![Active][active-badge]   | Very fast | 7.5/10, near instant responses with a recent model.                                         |
+| Replicate          | mixtral-8x7b                              | ✅         | ![Active][active-badge]   | Medium    | ?/10                                                                                        |
+| Replicate          | meta-llama-3-70b                          | ✅         | ![Unknown][unknown-badge] | Medium    | ?/10                                                                                        |
+| Replicate          | meta-llama-3-8b                           | ✅         | ![Active][active-badge]   | Fast      | ?/10                                                                                        |
+| Google Gemini      | auto (gemini-1.5-pro or gemini-1.5-flash) | ✅         | ![Active][active-badge]   | Very fast | 8/10, very good overall model but requires an API Key. (It's *free*, see the section below) |
+| GPT4Free Local API | -                                         | ✅         | ![Active][active-badge]   | -         | allows access to a large variety of providers. [read more][g4f-api-help]                    |
 
 ### Provider-specific notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@raycast/api": "^1.77.1",
         "g4f-image": "^1.0.0",
-        "gemini-g4f": "^12.3.5",
+        "gemini-g4f": "^12.3.6",
         "node-fetch": "^3.3.2"
       },
       "devDependencies": {
@@ -1197,9 +1197,9 @@
       "integrity": "sha512-qoRivJW+NQ5Mo9v+xtmGL/Jt8dZJAIZvpJhNwICB14IGEwmFRNamvZgvQ/y7QFpjpM/VjKVxrKs2xoJGuKsNDA=="
     },
     "node_modules/gemini-g4f": {
-      "version": "12.3.5",
-      "resolved": "https://registry.npmjs.org/gemini-g4f/-/gemini-g4f-12.3.5.tgz",
-      "integrity": "sha512-FKg0pvDoXnIsFt96DZrmf6j7jYaLT8WcQEzP2fcuxIt6lV2Iw7MPCgZp//jjh7Q0wurj1H1h2mTIQgvIeNEDEQ==",
+      "version": "12.3.6",
+      "resolved": "https://registry.npmjs.org/gemini-g4f/-/gemini-g4f-12.3.6.tgz",
+      "integrity": "sha512-vSWTaLTuoGKtN8bskpmRhQpJJ84IaxH1EXl3gQgHK4m6QeO8tuK03tB39ySwxJHiiST/v8wnbHYfJeUAO2oLqA==",
       "dependencies": {
         "file-type": "^19.0.0",
         "mime-lite": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -367,7 +367,7 @@
   "dependencies": {
     "@raycast/api": "^1.77.1",
     "g4f-image": "^1.0.0",
-    "gemini-g4f": "^12.3.5",
+    "gemini-g4f": "^12.3.6",
     "node-fetch": "^3.3.2"
   },
   "devDependencies": {

--- a/src/api/Providers/google_gemini.jsx
+++ b/src/api/Providers/google_gemini.jsx
@@ -21,6 +21,7 @@ export const getGoogleGeminiResponse = async (chat, options, stream_update, max_
     for (const APIKey of APIKeys) {
       const googleGemini = new Gemini(APIKey, { fetch: fetch });
       let [formattedChat, query] = await GeminiFormatChat(chat, googleGemini);
+
       const geminiChat = googleGemini.createChat({
         model: options.model,
         messages: formattedChat,

--- a/src/api/Providers/google_gemini.jsx
+++ b/src/api/Providers/google_gemini.jsx
@@ -21,12 +21,11 @@ export const getGoogleGeminiResponse = async (chat, options, stream_update, max_
     for (const APIKey of APIKeys) {
       const googleGemini = new Gemini(APIKey, { fetch: fetch });
       let [formattedChat, query] = await GeminiFormatChat(chat, googleGemini);
-
       const geminiChat = googleGemini.createChat({
         model: options.model,
         messages: formattedChat,
-        maxOutputTokens: 8192, // accurate as of 2024-05-31, for gemini-1.5-flash-latest
-        temperature: options.temperature,
+        maxOutputTokens: 8192, // maximum for v1.5 models
+        temperature: options.temperature * 1.5, // v1.5 models have temperature in [0, 2] so we scale it up
       });
 
       // Send message

--- a/src/api/providers.jsx
+++ b/src/api/providers.jsx
@@ -53,7 +53,7 @@ export const providers_info = {
   ReplicateLlama3_8B: { provider: ReplicateProvider, model: "meta/meta-llama-3-8b-instruct", stream: true },
   ReplicateLlama3_70B: { provider: ReplicateProvider, model: "meta/meta-llama-3-70b-instruct", stream: true },
   ReplicateMixtral_8x7B: { provider: ReplicateProvider, model: "mistralai/mixtral-8x7b-instruct-v0.1", stream: true },
-  GoogleGemini: { provider: GeminiProvider, model: "gemini-1.5-flash-latest", stream: true },
+  GoogleGemini: { provider: GeminiProvider, model: "auto", stream: true },
   G4FLocal: { provider: G4FLocalProvider, stream: true },
 };
 


### PR DESCRIPTION
We try to use gemini-1.5-pro first, and if we are rate limited, we switch to gemini-1.5-flash.
Gemini-1.5-pro is an even more capable model than its faster counterpart.

See https://github.com/XInTheDark/gemini-ai/commit/9b50785b42d23eb94f7ce2e8c0f32db79b5fba2f.