### PR TITLE
Fix Blackbox formatting

### DIFF
--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -495,13 +495,11 @@ export const formatResponse = (response, provider = null) => {
   }
 
   if (provider === providers.BlackboxProvider) {
-    // replace only once
-    // example: remove $@$v=v1.13$@$ or $@$v=undefined%@$
+    // remove version number - example: remove $@$v=v1.13$@$ or $@$v=undefined%@$
     response = response.replace(/\$@\$v=.{1,30}\$@\$/, "");
 
-    // remove sources
-    // remove the chunk of text starting with $~~~$[ and ending with ]$~~~$
-    response = response.replace(/\$~~~\$\[.*]\$~~~\$/, "");
+    // remove sources - the chunk of text starting with $~~~$[ and ending with ]$~~~$
+    response = response.replace(/\$~~~\$\[[^]*]\$~~~\$/, "");
   }
 
   return response;


### PR DESCRIPTION
The dot (.) does not match newlines by default, so .* failed to match content that spans multiple lines.