### PR TITLE
Allow file uploads for all providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ updating manually also allows you to fetch and view the latest changes to the so
 | Rocks                        | llama-3.1-405b                          | ▶️       | ![Active][active-badge]     | Fast           | 7.5/10                                                                                      |
 | Rocks                        | llama-3.1-70b                           | ▶️       | ![Active][active-badge]     | Very Fast      | 7/10                                                                                        |
 | ChatgptFree                  | gpt-4o-mini                             | ▶️       | ![Active][active-badge]     | Extremely fast | 8.5/10                                                                                      |
-| PizzaGPT                     | gpt-3.5-turbo                           |          | ![Active][active-badge]     | Extremely fast | 6.5/10                                                                                      |
+| PizzaGPT                     | gpt-4o-mini                             |          | ![Active][active-badge]     | Extremely fast | 7.5/10                                                                                      |
 | Meta AI                      | meta-llama-3.1                          | ▶️       | ![Active][active-badge]     | Medium         | 7/10, recent model with internet access.                                                    |
 | Replicate                    | mixtral-8x7b                            | ▶️       | ![Active][active-badge]     | Medium         | ?/10                                                                                        |
 | Replicate                    | meta-llama-3.1-405b                     | ▶️       | ![Active][active-badge]     | Medium         | ?/10                                                                                        |
@@ -117,6 +117,7 @@ updating manually also allows you to fetch and view the latest changes to the so
 ▶️ - Supports streaming.
 
 📄 - Supports file upload.
+**Note**: By default, all providers support basic file upload functionality for text-based files, like .txt, .md, etc.
 
 *¹: Supports images only.*
 

--- a/src/api/Providers/nexra.jsx
+++ b/src/api/Providers/nexra.jsx
@@ -1,5 +1,5 @@
 import fetch from "node-fetch";
-import { messages_to_json } from "../../classes/message";
+import { format_chat_to_prompt, messages_to_json } from "../../classes/message";
 
 // Reference: https://nexra.aryahcr.cc/documentation/chatgpt/en (under ChatGPT v2)
 const api_url_stream = "https://nexra.aryahcr.cc/api/chat/complements";
@@ -20,7 +20,12 @@ export const NexraProvider = {
 };
 
 export const getNexraResponseStream = async function* (chat, options, max_retries = 5) {
-  chat = messages_to_json(chat);
+  if (["Bing"].includes(options.model)) {
+    chat = [{ role: "user", content: format_chat_to_prompt(chat) }];
+  } else {
+    chat = messages_to_json(chat);
+  }
+
   let data = {
     messages: chat,
     stream: true,

--- a/src/api/Providers/phind.jsx
+++ b/src/api/Providers/phind.jsx
@@ -1,5 +1,6 @@
 import { curlRequest } from "../curl";
 import { DEFAULT_HEADERS } from "../../helpers/headers";
+import { messages_to_json } from "../../classes/message";
 
 const url = "https://www.phind.com";
 const home_url = "https://www.phind.com/search?home=true";
@@ -34,6 +35,7 @@ export const PhindProvider = {
     stdout = null;
 
     // prepare data
+    chat = messages_to_json(chat);
     let prompt = chat[chat.length - 1].content;
     chat.pop();
 

--- a/src/api/Providers/replicate.jsx
+++ b/src/api/Providers/replicate.jsx
@@ -1,5 +1,5 @@
 import fetch from "node-fetch";
-import { format_chat_to_prompt, messages_to_json } from "../../classes/message";
+import { format_chat_to_prompt } from "../../classes/message";
 
 // Implementation ported from gpt4free Replicate provider.
 
@@ -13,7 +13,6 @@ export const ReplicateProvider = {
   name: "Replicate",
   generate: async function* (chat, options, { max_retries = 10 }) {
     const model = options.model;
-    chat = messages_to_json(chat);
 
     let data = {
       stream: true,

--- a/src/classes/message.jsx
+++ b/src/classes/message.jsx
@@ -140,7 +140,7 @@ export const messages_to_json = (chat, { readFiles = true } = {}) => {
       for (const file of msg.files) {
         // read text
         let text = fs.readFileSync(file, "utf8");
-        text = `---\n${file}\n\n${text}`;
+        text = `---\nFile: ${file}\n\n${text}`;
 
         // push as new message
         json.push({ role: "user", content: text });

--- a/src/classes/message.jsx
+++ b/src/classes/message.jsx
@@ -9,6 +9,8 @@
 //
 // Note how we currently don't have a Chat class, and instead we just use an array of messages.
 
+import fs from "fs";
+
 export class Message {
   constructor({ role = "", content = "", files = [] } = {}) {
     this.role = role;
@@ -88,6 +90,8 @@ export const pairs_to_messages = (pairs, query = null) => {
 
 // Format an array of Messages into a single string
 export const format_chat_to_prompt = (chat, model = null) => {
+  chat = messages_to_json(chat);
+
   model = model?.toLowerCase() || "";
   let prompt = "";
 
@@ -120,11 +124,30 @@ export const format_chat_to_prompt = (chat, model = null) => {
 
 // Format an array of Messages (NOT pairs) into a simple JSON array consisting of role and content,
 // and occasionally other properties (e.g. tool call info). this is used in many OpenAI-based APIs.
-// Currently, the only modification is to remove the files property.
-export const messages_to_json = (chat) => {
+//
+// Modifications:
+// - read files if any, and add them to the message. (unless the provider doesn't want us to include files)
+// - remove the files property
+
+export const messages_to_json = (chat, {readFiles = true} = {}) => {
   let json = [];
+
   for (let i = 0; i < chat.length; i++) {
     let msg = structuredClone(chat[i]);
+
+    if (readFiles && msg.files && msg.files.length > 0) {
+      console.assert(msg.role === "user", "Only user messages can have files");
+      for (const file of msg.files) {
+        // read text
+        let text = fs.readFileSync(file, "utf8");
+        text = `---\n${file}\n\n${text}`;
+
+        // push as new message
+        json.push({ role: "user", content: text });
+        json.push({ role: "assistant", content: "" });
+      }
+    }
+
     delete msg.files;
     json.push(msg);
   }

--- a/src/classes/message.jsx
+++ b/src/classes/message.jsx
@@ -144,7 +144,7 @@ export const messages_to_json = (chat, { readFiles = true } = {}) => {
 
         // push as new message
         json.push({ role: "user", content: text });
-        json.push({ role: "assistant", content: "" });
+        json.push({ role: "assistant", content: "[system: file uploaded]" });
       }
     }
 

--- a/src/classes/message.jsx
+++ b/src/classes/message.jsx
@@ -129,7 +129,7 @@ export const format_chat_to_prompt = (chat, model = null) => {
 // - read files if any, and add them to the message. (unless the provider doesn't want us to include files)
 // - remove the files property
 
-export const messages_to_json = (chat, {readFiles = true} = {}) => {
+export const messages_to_json = (chat, { readFiles = true } = {}) => {
   let json = [];
 
   for (let i = 0; i < chat.length; i++) {


### PR DESCRIPTION
For providers that don't natively support file uploads, we try to read the file as text, then add it directly as a message.