### PR TITLE
Rewrite Web Search feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ There are 4 options:
 *¹: Commands that support Web Search are: Ask AI, Ask About Selected Text, Explain. Other commands will not use Web
 Search.*
 
+Web Search is also available in the following commands:
+- Custom AI Commands: You can enable Web Search for each command individually.
+- AI Chat: You can enable Web Search for each chat individually.
+- AI Presets: You can enable Web Search for each preset individually.
+
 ### Smart Chat Naming
 
 Let GPT automatically come up with a name for the current chat session after you send the first message. For example,

--- a/README.md
+++ b/README.md
@@ -147,6 +147,20 @@ separate them with commas in the preferences.
 Let GPT decide to search the web for information if it does not have enough knowledge or context. Uses DuckDuckGo
 search, fast and free.
 
+#### Usage
+
+Enabling web search is fast and easy. Go to the extension preferences, and the "Web Search" option will be available.
+There are 4 options:
+
+- Disabled (default)
+- Automatic: Enable Web Search only in AI Chat. GPT will automatically decide when to use it.
+- Balanced: Use Web Search in every query for AI commands¹, and automatically in AI Chat. This is basically an extension
+  of the "Automatic" option.
+- Always: Always use Web Search for every query, both in AI Chat and in commands¹.
+
+*¹: Commands that support Web Search are: Ask AI, Ask About Selected Text, Explain. Other commands will not use Web
+Search.*
+
 ### Smart Chat Naming
 
 Let GPT automatically come up with a name for the current chat session after you send the first message. For example,

--- a/package.json
+++ b/package.json
@@ -410,7 +410,7 @@
     {
       "name": "webSearch",
       "title": "Web Search",
-      "description": "Add web search capabilities to GPT.",
+      "description": "Allow GPT to search the web for information.",
       "required": false,
       "type": "dropdown",
       "data": [

--- a/package.json
+++ b/package.json
@@ -423,8 +423,8 @@
           "value": "auto"
         },
         {
-          "title": "Hybrid",
-          "value": "hybrid"
+          "title": "Balanced",
+          "value": "balanced"
         },
         {
           "title": "Always",

--- a/package.json
+++ b/package.json
@@ -409,15 +409,29 @@
     },
     {
       "name": "webSearch",
-      "title": "Features",
-      "label": "Enable Web Search",
-      "description": "Add web search capabilities to GPT. Available in AI Chat.",
+      "title": "Web Search",
+      "description": "Add web search capabilities to GPT.",
       "required": false,
-      "type": "checkbox",
-      "default": false
+      "type": "dropdown",
+      "data": [
+        {
+          "title": "Disabled",
+          "value": "off"
+        },
+        {
+          "title": "Automatic",
+          "value": "auto"
+        },
+        {
+          "title": "Always",
+          "value": "always"
+        }
+      ],
+      "default": "off"
     },
     {
       "name": "smartChatNaming",
+      "title": "Features",
       "label": "Enable Smart Chat Naming",
       "description": "Automatically rename chat sessions based on the messages you send.",
       "required": false,

--- a/package.json
+++ b/package.json
@@ -423,6 +423,10 @@
           "value": "auto"
         },
         {
+          "title": "Hybrid",
+          "value": "hybrid"
+        },
+        {
           "title": "Always",
           "value": "always"
         }

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -28,7 +28,7 @@ import * as providers from "./api/providers";
 import { getAIPresets, getPreset } from "./helpers/presets";
 
 // Web search module
-import { formatWebResult, getWebResult, has_native_web_search } from "./api/tools/web";
+import { formatWebResult, getWebResult, has_native_web_search, web_search_mode } from "./api/tools/web";
 import { webSystemPrompt, systemResponse, webToken, webTokenEnd } from "./api/tools/web";
 
 let generationStatus = { stop: false, loading: false, updateCurrentResponse: false };
@@ -174,7 +174,7 @@ export default function Chat({ launchContext }) {
     provider = providers.default_provider_string(),
     systemPrompt = "",
     messages = [],
-    options = { creativity: "0.7", webSearch: getPreferenceValues()["webSearch"] },
+    options = { creativity: "0.7", webSearch: web_search_mode("chat") },
   }) => {
     return {
       name: name,
@@ -531,7 +531,7 @@ export default function Chat({ launchContext }) {
         </Form.Dropdown>
 
         <Form.Description title="Web Search" text="Allow GPT to search the web for information." />
-        <Form.Dropdown id="webSearch" defaultValue={chat?.options?.webSearch ?? getPreferenceValues()["webSearch"]}>
+        <Form.Dropdown id="webSearch" defaultValue={chat?.options?.webSearch ?? web_search_mode("chat")}>
           <Form.Dropdown.Item title="Disabled" value="off" />
           <Form.Dropdown.Item title="Automatic" value="auto" />
           <Form.Dropdown.Item title="Always" value="always" />

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -193,7 +193,7 @@ export default function Chat({ launchContext }) {
     provider = provider instanceof Object ? provider : providers.get_provider_info(provider).provider;
 
     // Web Search system prompt
-    if (!has_native_web_search(provider) && ["auto", "always"].includes(webSearch)) {
+    if (webSearch === "always" || (webSearch === "auto" && !has_native_web_search(provider))) {
       systemPrompt += "\n\n" + webSystemPrompt;
     }
 
@@ -245,7 +245,12 @@ export default function Chat({ launchContext }) {
 
     const info = providers.get_provider_info(currentChatData.provider);
 
-    const webSearchMode = has_native_web_search(info.provider) ? "off" : currentChatData.options.webSearch;
+    const webSearchMode =
+      currentChatData.options.webSearch === "auto"
+        ? has_native_web_search(info.provider)
+          ? "off"
+          : "auto"
+        : currentChatData.options.webSearch;
 
     let elapsed = 0.001,
       chars,
@@ -256,7 +261,8 @@ export default function Chat({ launchContext }) {
     let loadingToast = await toast(Toast.Style.Animated, "Response loading");
 
     // Handle web search - if always enabled, we get the web search results
-    if (webSearchMode === "always") {
+    if (webSearchMode === "always" && features.webSearch) {
+      query = query ?? currentChatData.messages[0].first.content;
       await processWebSearchResponse(currentChatData, setCurrentChatData, messageID, null, query);
       return;
     }

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -240,7 +240,6 @@ export default function Chat({ launchContext }) {
     query = null,
     features = { webSearch: true }
   ) => {
-    console.log(currentChatData);
     setCurrentChatMessage(currentChatData, setCurrentChatData, messageID, { response: "" }); // set response to empty string
 
     const info = providers.get_provider_info(currentChatData.provider);

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -28,7 +28,7 @@ import * as providers from "./api/providers";
 import { getAIPresets, getPreset } from "./helpers/presets";
 
 // Web search module
-import { getWebResult, web_search_enabled } from "./api/tools/web";
+import { formatWebResult, getWebResult, web_search_enabled } from "./api/tools/web";
 import { webSystemPrompt, systemResponse, webToken, webTokenEnd } from "./api/tools/web";
 
 let generationStatus = { stop: false, loading: false, updateCurrentResponse: false };
@@ -747,7 +747,7 @@ export default function Chat({ launchContext }) {
       ? response.substring(response.indexOf(webToken) + webToken.length, response.indexOf(webTokenEnd)).trim()
       : response.substring(response.indexOf(webToken) + webToken.length).trim();
     let webResponse = await getWebResult(webQuery);
-    webResponse = `\n\n<|web_search_results|> for "${webQuery}":\n\n` + webResponse;
+    webResponse = formatWebResult(webResponse, webQuery);
 
     // Append web search results to the last user message
     // special case: If e.g. the message was edited, query is not passed as a parameter, so it is null

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -771,7 +771,7 @@ export default function Chat({ launchContext }) {
   // Web Search functionality
   const processWebSearchResponse = async (currentChatData, setCurrentChatData, messageID, response, query) => {
     setCurrentChatMessage(currentChatData, setCurrentChatData, messageID, { finished: false });
-    await toast(Toast.Style.Animated, "Searching web");
+
     let webQuery = response
       ? // get everything AFTER webToken and BEFORE webTokenEnd
         response.includes(webTokenEnd)

--- a/src/api/Providers/deepinfra.jsx
+++ b/src/api/Providers/deepinfra.jsx
@@ -2,7 +2,7 @@ import fetch from "node-fetch";
 import fs from "fs";
 
 import { messages_to_json } from "../../classes/message";
-import { getWebResult, webSearchTool } from "../tools/web";
+import { getWebResult, web_search_enabled, webSearchTool } from "../tools/web";
 import { codeInterpreterTool, getCodeInterpreterResult } from "../tools/code";
 import { getPreferenceValues } from "@raycast/api";
 
@@ -92,7 +92,7 @@ export const DeepInfraProvider = {
     const model = options.model;
     const json_chat = DeepInfraFormatChat(chat, model);
 
-    const useWebSearch = getPreferenceValues()["webSearch"] && function_supported_models.includes(model);
+    const useWebSearch = web_search_enabled() && function_supported_models.includes(model);
     const useCodeInterpreter = getPreferenceValues()["codeInterpreter"] && function_supported_models.includes(model);
     const tools = [...(useWebSearch ? [webSearchTool] : []), ...(useCodeInterpreter ? [codeInterpreterTool] : [])];
 

--- a/src/api/Providers/deepinfra.jsx
+++ b/src/api/Providers/deepinfra.jsx
@@ -92,7 +92,7 @@ export const DeepInfraProvider = {
     const model = options.model;
     const json_chat = DeepInfraFormatChat(chat, model);
 
-    const useWebSearch = web_search_enabled() && function_supported_models.includes(model);
+    const useWebSearch = options.webSearch === "auto" && function_supported_models.includes(model);
     const useCodeInterpreter = getPreferenceValues()["codeInterpreter"] && function_supported_models.includes(model);
     const tools = [...(useWebSearch ? [webSearchTool] : []), ...(useCodeInterpreter ? [codeInterpreterTool] : [])];
 

--- a/src/api/Providers/deepinfra.jsx
+++ b/src/api/Providers/deepinfra.jsx
@@ -2,7 +2,7 @@ import fetch from "node-fetch";
 import fs from "fs";
 
 import { messages_to_json } from "../../classes/message";
-import { getWebResult, web_search_enabled, webSearchTool } from "../tools/web";
+import { getWebResult, web_search_mode, webSearchTool } from "../tools/web";
 import { codeInterpreterTool, getCodeInterpreterResult } from "../tools/code";
 import { getPreferenceValues } from "@raycast/api";
 

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -43,6 +43,7 @@ export default (
     allowUploadFiles = false,
     defaultFiles = [],
     useDefaultLanguage = false,
+    allowWebSearch = true,
   } = {}
 ) => {
   // The parameters are documented here:
@@ -76,6 +77,7 @@ export default (
   // 10. allowUploadFiles: A boolean to allow uploading files in the Form. If true, a file upload field will be shown.
   // 11. defaultFiles: Files to always include in the prompt. This is an array of file paths.
   // 12. useDefaultLanguage: A boolean to use the default language. If true, the default language will be used in the response.
+  // 13. allowWebSearch: A boolean to allow web search. If false, we will never make a web search. Otherwise, the extension preferences are followed.
 
   /// Init
   const Pages = {
@@ -126,7 +128,7 @@ export default (
       }
 
       // handle web search - if set to "always", we will include web search results in the prompt
-      if (web_search_enabled(info.provider, ["always"])) {
+      if (allowWebSearch && web_search_enabled(info.provider, ["always"])) {
         // push system prompt
         messages = [
           new Message({ role: "user", content: webSystemPrompt }),

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -43,7 +43,7 @@ export default (
     allowUploadFiles = false,
     defaultFiles = [],
     useDefaultLanguage = false,
-    allowWebSearch = true,
+    allowWebSearch = false,
   } = {}
 ) => {
   // The parameters are documented here:

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -24,7 +24,7 @@ import { autoCheckForUpdates } from "../helpers/update";
 import { Message, pairs_to_messages } from "../classes/message";
 
 import { truncate_chat } from "../helpers/helper";
-import { formatWebResult, getWebResult, systemResponse, web_search_enabled, webSystemPrompt } from "./tools/web";
+import { formatWebResult, getWebResult, systemResponse, web_search_mode, webSystemPrompt } from "./tools/web";
 
 let generationStatus = { stop: false, loading: false };
 let get_status = () => generationStatus.stop;
@@ -128,7 +128,7 @@ export default (
       }
 
       // handle web search - if set to "always", we will include web search results in the prompt
-      if (allowWebSearch && web_search_enabled(info.provider, ["always"])) {
+      if (allowWebSearch && web_search_mode("gpt", info.provider)) {
         // push system prompt
         messages = [
           new Message({ role: "user", content: webSystemPrompt }),

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -43,7 +43,7 @@ export default (
     allowUploadFiles = false,
     defaultFiles = [],
     useDefaultLanguage = false,
-    allowWebSearch = false,
+    webSearchMode = "off",
   } = {}
 ) => {
   // The parameters are documented here:
@@ -77,7 +77,8 @@ export default (
   // 10. allowUploadFiles: A boolean to allow uploading files in the Form. If true, a file upload field will be shown.
   // 11. defaultFiles: Files to always include in the prompt. This is an array of file paths.
   // 12. useDefaultLanguage: A boolean to use the default language. If true, the default language will be used in the response.
-  // 13. allowWebSearch: A boolean to allow web search. If false, we will never make a web search. Otherwise, the extension preferences are followed.
+  // 13. webSearchMode: A string to allow web search. If "always", we will always search.
+  // Otherwise, if "auto", the extension preferences are followed.
 
   /// Init
   const Pages = {
@@ -127,8 +128,8 @@ export default (
         }
       }
 
-      // handle web search - if set to "always", we will include web search results in the prompt
-      if (allowWebSearch && web_search_mode("gpt", info.provider)) {
+      // handle web search
+      if (webSearchMode === "always" || (webSearchMode === "auto" && web_search_mode("gpt", info.provider))) {
         // push system prompt
         messages = [
           new Message({ role: "user", content: webSystemPrompt }),

--- a/src/api/tools/web.jsx
+++ b/src/api/tools/web.jsx
@@ -92,8 +92,14 @@ export const processWebResults = (results, maxResults = 15) => {
   return answer;
 };
 
+export const formatWebResult = (webResponse, webQuery = null) => {
+  return `\n\n<|web_search_results|> ${webQuery && `for "${webQuery}`}":\n\n` + webResponse;
+};
+
 // Check if web search should be enabled.
 // Providers that support function calling should handle web search separately
-export const web_search_enabled = (provider) => {
-  return getPreferenceValues()["webSearch"] && !providers.function_supported_providers.includes(provider);
+export const web_search_enabled = (provider = null, allowed = ["auto", "always"]) => {
+  return (
+    allowed.includes(getPreferenceValues()["webSearch"]) && !providers.function_supported_providers.includes(provider)
+  );
 };

--- a/src/api/tools/web.jsx
+++ b/src/api/tools/web.jsx
@@ -64,6 +64,7 @@ export const webSearchTool = {
 
 export const getWebResult = async (query) => {
   console.log("Web search query:", query);
+  await showToast(Toast.Style.Animated, "Searching the web");
 
   try {
     const searchResults = await DDG.search(query, {

--- a/src/api/tools/web.jsx
+++ b/src/api/tools/web.jsx
@@ -108,10 +108,10 @@ export const web_search_mode = (type, provider = null) => {
   const pref = getPreferenceValues()["webSearch"];
   if (type === "gpt") {
     // AI commands
-    return ["hybrid", "always"].includes(pref) && !has_native_web_search(provider);
+    return ["balanced", "always"].includes(pref) && !has_native_web_search(provider);
   } else if (type === "chat") {
     // AI Chat
-    return pref === "hybrid" ? "auto" : pref;
+    return pref === "balanced" ? "auto" : pref;
   } else {
     return pref;
   }

--- a/src/api/tools/web.jsx
+++ b/src/api/tools/web.jsx
@@ -101,7 +101,18 @@ export const has_native_web_search = (provider) => {
 };
 
 // Check if web search should be enabled.
-// Providers that support function calling should handle web search separately
-export const web_search_enabled = (provider = null, allowed = ["auto", "always"]) => {
-  return allowed.includes(getPreferenceValues()["webSearch"]) && !has_native_web_search(provider);
+// If called in AI commands, we return a boolean - whether to use web search or not.
+// Otherwise, we return a string - the mode of web search.
+// Note: providers that support function calling should handle web search separately
+export const web_search_mode = (type, provider = null) => {
+  const pref = getPreferenceValues()["webSearch"];
+  if (type === "gpt") {
+    // AI commands
+    return ["hybrid", "always"].includes(pref) && !has_native_web_search(provider);
+  } else if (type === "chat") {
+    // AI Chat
+    return pref === "hybrid" ? "auto" : pref;
+  } else {
+    return pref;
+  }
 };

--- a/src/api/tools/web.jsx
+++ b/src/api/tools/web.jsx
@@ -93,13 +93,15 @@ export const processWebResults = (results, maxResults = 15) => {
 };
 
 export const formatWebResult = (webResponse, webQuery = null) => {
-  return `\n\n<|web_search_results|> ${webQuery && `for "${webQuery}`}":\n\n` + webResponse;
+  return `\n\n<|web_search_results|> ${webQuery ? `for "${webQuery}` : ""}":\n\n` + webResponse;
+};
+
+export const has_native_web_search = (provider) => {
+  return providers.function_supported_providers.includes(provider);
 };
 
 // Check if web search should be enabled.
 // Providers that support function calling should handle web search separately
 export const web_search_enabled = (provider = null, allowed = ["auto", "always"]) => {
-  return (
-    allowed.includes(getPreferenceValues()["webSearch"]) && !providers.function_supported_providers.includes(provider)
-  );
+  return allowed.includes(getPreferenceValues()["webSearch"]) && !has_native_web_search(provider);
 };

--- a/src/askAI.jsx
+++ b/src/askAI.jsx
@@ -7,5 +7,5 @@ export default function AskAI(props) {
     let _params = props?.launchContext?.params || {};
     return useGPT(_props, _params);
   }
-  return useGPT(props, { showFormText: "Prompt", allowUploadFiles: true, allowWebSearch: true });
+  return useGPT(props, { showFormText: "Prompt", allowUploadFiles: true, webSearchMode: "auto" });
 }

--- a/src/askAI.jsx
+++ b/src/askAI.jsx
@@ -7,5 +7,5 @@ export default function AskAI(props) {
     let _params = props?.launchContext?.params || {};
     return useGPT(_props, _params);
   }
-  return useGPT(props, { showFormText: "Prompt", allowUploadFiles: true });
+  return useGPT(props, { showFormText: "Prompt", allowUploadFiles: true, allowWebSearch: true });
 }

--- a/src/askAboutSelectedText.jsx
+++ b/src/askAboutSelectedText.jsx
@@ -1,5 +1,5 @@
 import useGPT from "./api/gpt";
 
 export default function AskAboutSelectedText(props) {
-  return useGPT(props, { allowPaste: true, useSelected: true, requireQuery: true, showFormText: "Query" });
+  return useGPT(props, { allowPaste: true, useSelected: true, requireQuery: true, showFormText: "Query", allowWebSearch: true });
 }

--- a/src/askAboutSelectedText.jsx
+++ b/src/askAboutSelectedText.jsx
@@ -6,6 +6,6 @@ export default function AskAboutSelectedText(props) {
     useSelected: true,
     requireQuery: true,
     showFormText: "Query",
-    allowWebSearch: true,
+    webSearchMode: "auto",
   });
 }

--- a/src/askAboutSelectedText.jsx
+++ b/src/askAboutSelectedText.jsx
@@ -1,5 +1,11 @@
 import useGPT from "./api/gpt";
 
 export default function AskAboutSelectedText(props) {
-  return useGPT(props, { allowPaste: true, useSelected: true, requireQuery: true, showFormText: "Query", allowWebSearch: true });
+  return useGPT(props, {
+    allowPaste: true,
+    useSelected: true,
+    requireQuery: true,
+    showFormText: "Query",
+    allowWebSearch: true,
+  });
 }

--- a/src/customAICommands.jsx
+++ b/src/customAICommands.jsx
@@ -37,6 +37,7 @@ export default function CustomAICommands() {
               onSubmit={async (values) => {
                 command.name = values.name;
                 command.prompt = values.prompt;
+                command.options.webSearch = values.webSearch;
                 command.options.allowUploadFiles = values.allowUploadFiles;
 
                 if (newCommand) {
@@ -58,11 +59,20 @@ export default function CustomAICommands() {
           title=""
           text="In the prompt, you can use dynamic placeholders like {input}, {clipboard} or {date}. Learn more by selecting the Help action."
         />
+
+        <Form.Separator />
+
+        <Form.Checkbox
+          id="webSearch"
+          title="Options"
+          label="Enable Web Search"
+          defaultValue={command.options?.webSearch}
+        />
         <Form.Checkbox
           id="allowUploadFiles"
-          title="Options"
           label="Allow File Uploads"
           info="Only certain providers support file uploads, please refer to the README for more info"
+          defaultValue={command.options?.allowUploadFiles}
         />
       </Form>
     );
@@ -120,6 +130,7 @@ export default function CustomAICommands() {
         useSelected: true,
         allowUploadFiles: command.options?.allowUploadFiles,
         processPrompt: command.processPromptFunction(),
+        webSearchMode: command.options?.webSearch ? "always" : "off",
       }
     );
   };

--- a/src/explain.jsx
+++ b/src/explain.jsx
@@ -7,5 +7,6 @@ export default function Explain(props) {
     useSelected: true,
     allowUploadFiles: true,
     useDefaultLanguage: true,
+    allowWebSearch: true,
   });
 }

--- a/src/explain.jsx
+++ b/src/explain.jsx
@@ -7,6 +7,6 @@ export default function Explain(props) {
     useSelected: true,
     allowUploadFiles: true,
     useDefaultLanguage: true,
-    allowWebSearch: true,
+    webSearchMode: "auto",
   });
 }

--- a/src/helpers/presets.jsx
+++ b/src/helpers/presets.jsx
@@ -1,9 +1,10 @@
 import { Storage } from "../api/storage";
 
 export class AIPreset {
-  constructor({ name = "", provider = undefined, creativity = undefined, systemPrompt = "" }) {
+  constructor({ name = "", provider = undefined, webSearch = "off", creativity = "0.7", systemPrompt = "" }) {
     this.name = name;
     this.provider = provider;
+    this.webSearch = webSearch;
     this.creativity = creativity;
     this.systemPrompt = systemPrompt;
   }
@@ -19,7 +20,9 @@ export const setAIPresets = async (presets) => {
 };
 
 export const getSubtitle = (preset) => {
-  return `Provider: ${preset.provider} | ${preset.systemPrompt.slice(0, 50)}`;
+  return `Provider: ${preset.provider} | ${
+    preset.webSearch !== "off" ? `Web Search: ${preset.webSearch} |` : ""
+  } ${preset.systemPrompt.slice(0, 50)}`;
 };
 
 export const getPreset = (presets, name) => {

--- a/src/manageAIPresets.jsx
+++ b/src/manageAIPresets.jsx
@@ -1,6 +1,17 @@
 import { AIPreset, getAIPresets, getSubtitle, setAIPresets } from "./helpers/presets";
 import { useEffect, useState } from "react";
-import { Form, List, Action, ActionPanel, Icon, useNavigation, confirmAlert, showToast, Toast } from "@raycast/api";
+import {
+  Form,
+  List,
+  Action,
+  ActionPanel,
+  Icon,
+  useNavigation,
+  confirmAlert,
+  showToast,
+  Toast,
+  getPreferenceValues,
+} from "@raycast/api";
 import { help_action } from "./helpers/helpPage";
 import * as providers from "./api/providers";
 
@@ -27,7 +38,12 @@ export default function ManageAIPresets() {
     const idx = props.idx ?? 0;
     const newPreset = props.newPreset || false;
     let preset = newPreset
-      ? new AIPreset({ name: "New Preset", provider: providers.default_provider_string(), creativity: "0.7" })
+      ? new AIPreset({
+          name: "New Preset",
+          provider: providers.default_provider_string(),
+          webSearch: getPreferenceValues()["webSearch"],
+          creativity: "0.7",
+        })
       : presets[idx];
 
     return (
@@ -49,6 +65,7 @@ export default function ManageAIPresets() {
 
                 preset.name = values.name;
                 preset.provider = values.provider;
+                preset.webSearch = values.webSearch;
                 preset.creativity = values.creativity;
                 preset.systemPrompt = values.systemPrompt;
 
@@ -69,6 +86,13 @@ export default function ManageAIPresets() {
         <Form.Description title="Provider" text="The provider and model used for this chat." />
         <Form.Dropdown id="provider" defaultValue={preset.provider}>
           {providers.ChatProvidersReact}
+        </Form.Dropdown>
+
+        <Form.Description title="Web Search" text="Allow GPT to search the web for information." />
+        <Form.Dropdown id="webSearch" defaultValue={preset.webSearch}>
+          <Form.Dropdown.Item title="Disabled" value="off" />
+          <Form.Dropdown.Item title="Automatic" value="auto" />
+          <Form.Dropdown.Item title="Always" value="always" />
         </Form.Dropdown>
 
         <Form.Description


### PR DESCRIPTION
This patch rewrites the Web Search feature by introducing four options: Disabled ("off"), Automatic ("auto"), Balanced ("balanced") and Always ("always").

The intended behaviour is as follows:
- If "off", then a web search will never be made.
- If "auto", the web search is only available in AI Chat. The model will choose whether to make web searches. (This is the same behaviour as before.)
- If "balanced", then in AI Chat we will set web search mode to "auto", while in AI commands we always search.
- If "always", a web search will always be made, both in AI Chat and (some) AI commands.

*Note: Only some AI commands will support web search, since in others (e.g. Summarize, Paraphrase) it makes little sense to search.*

Additionally, in AI Chat, the user can now choose individual web search settings for each chat. Similarly, the web search setting can also be changed in AI Presets and AI Commands.

Todo:
- [x] document