### PR TITLE
Support rendering as plain text

### DIFF
--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -24,6 +24,7 @@ import { autoCheckForUpdates } from "../helpers/update";
 import { Message, pairs_to_messages } from "../classes/message";
 
 import { truncate_chat } from "../helpers/helper";
+import { plainTextMarkdown } from "../helpers/markdown";
 import { formatWebResult, getWebResult, systemResponse, web_search_mode, webSystemPrompt } from "./tools/web";
 import { NexraProvider } from "./Providers/nexra";
 
@@ -45,6 +46,7 @@ export default (
     defaultFiles = [],
     useDefaultLanguage = false,
     webSearchMode = "off",
+    displayPlainText = false,
   } = {}
 ) => {
   // The parameters are documented here:
@@ -80,6 +82,7 @@ export default (
   // 12. useDefaultLanguage: A boolean to use the default language. If true, the default language will be used in the response.
   // 13. webSearchMode: A string to allow web search. If "always", we will always search.
   // Otherwise, if "auto", the extension preferences are followed.
+  // 14. displayPlainText: A boolean to display the response as plain text. If true, we attempt to convert the markdown to plain text.
 
   /// Init
   const Pages = {
@@ -87,11 +90,19 @@ export default (
     Detail: 1,
   };
   const [page, setPage] = useState(Pages.Detail);
-  const [markdown, setMarkdown] = useState("");
+  const [markdown, _setMarkdown] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [selectedState, setSelected] = useState("");
   const [lastQuery, setLastQuery] = useState({ text: "", files: [] });
   const [lastResponse, setLastResponse] = useState("");
+
+  const setMarkdown = (text) => {
+    if (displayPlainText) {
+      _setMarkdown(plainTextMarkdown(text));
+    } else {
+      _setMarkdown(text);
+    }
+  };
 
   // Init parameters
   let { query: argQuery } = props.arguments ?? {};

--- a/src/format.jsx
+++ b/src/format.jsx
@@ -6,5 +6,6 @@ export default function Format(props) {
     useSelected: true,
     showFormText: "Text",
     allowPaste: true,
+    displayPlainText: true,
   });
 }

--- a/src/helpers/markdown.jsx
+++ b/src/helpers/markdown.jsx
@@ -1,0 +1,28 @@
+// Convert markdown so that it is rendered as plain text.
+// Useful because Detail only supports markdown, and sometimes we want to show plain text.
+export function plainTextMarkdown(text) {
+  // Escape special markdown characters
+  const escapeChars1 = ["`", "*", "_"];
+  for (const char of escapeChars1) {
+    // always escape
+    text = text.replace(new RegExp(`\\${char}`, "g"), `\\${char}`);
+  }
+
+  const escapeChars2 = ["#", "[", "]", "(", ")", "<", ">", "-", "+", "{", "}", ".", "!"];
+  for (const char of escapeChars2) {
+    // replace only if it's surrounded by whitespace or at the beginning/end of a line
+    text = text.replace(new RegExp(`(^|\\s)\\${char}(\\s|$)`, "g"), `$1\\${char}$2`);
+  }
+
+  // If a line has no content except spaces, strip it
+  // This is useful for creating paragraphs
+  text = text.replace(/^\s+$/gm, "");
+
+  // Replace spaces with non-breaking spaces (U+00A0)
+  text = text.replace(/ /g, "\u00A0");
+
+  // Add two spaces at the end of each line for line breaks
+  text = text.replace(/(\S)(\n)(?!\n)/g, "$1  $2");
+
+  return text;
+}


### PR DESCRIPTION
In certain contexts, we want to render as plain text - e.g. the Format Text command.

The Detail view only supports markdown currently, so we perform modifications on the markdown to render it as plain text. It's not a perfect implementation, but most of the time it works correctly.

This feature has been added to:
- a new "View as Plain Text" command in AI Chat
- Format Text command