### PR TITLE
Add cursor icon during response loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ Enable more persistent storage of the extension's data, like AI Chat data or Cus
 This will back up a copy of this data to files on your computer. Useful for saving large amounts of data.
 *Note: With this option off, your data is already well preserved. Do not enable this if you have sensitive data.*
 
+### Enable Cursor Icon
+
+Show a cursor icon when the response is loading - cosmetic option only.
+
 ### Code Interpreter (BETA)
 
 Allows GPT to execute Python code locally. The model has been instructed to strictly only produce safe code,

--- a/package.json
+++ b/package.json
@@ -480,6 +480,14 @@
       "default": false
     },
     {
+      "name": "useCursorIcon",
+      "label": "Enable Cursor Icon",
+      "description": "Show a cursor icon when the response is loading.",
+      "required": false,
+      "type": "checkbox",
+      "default": true
+    },
+    {
       "name": "codeInterpreter",
       "label": "Enable Code Interpreter (BETA)",
       "description": "Allows GPT to interpret and run Python code locally, based on your queries. Use at your own risk!",


### PR DESCRIPTION
Show a cursor icon when the response is loading - cosmetic option only.

The emoji used is a filled circle (●), similar to what was previously used in ChatGPT.