### PR TITLE
Add Browser Extension support

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,22 @@
       ]
     },
     {
+      "name": "askAboutBrowserTab",
+      "title": "Ask About Browser Tab",
+      "description": "Ask GPT about browser tab",
+      "icon": "screen-icon.png",
+      "mode": "view",
+      "arguments": [
+        {
+          "name": "query",
+          "placeholder": "Query",
+          "type": "text",
+          "required": false
+        }
+      ],
+      "disabledByDefault": true
+    },
+    {
       "name": "continue",
       "title": "Continue Text",
       "description": "Generate completion of text",

--- a/src/askAboutBrowserTab.jsx
+++ b/src/askAboutBrowserTab.jsx
@@ -1,0 +1,14 @@
+import useGPT from "./api/gpt";
+import { getBrowserTab } from "./helpers/browser";
+
+export default function AskAboutBrowserTab(props) {
+  return useGPT(props, {
+    allowPaste: true,
+    requireQuery: true,
+    showFormText: "Query",
+    processPrompt: async ({ query }) => {
+      const browserTab = await getBrowserTab();
+      return `Browser tab content: ${browserTab}\n\n${query}`;
+    },
+  });
+}

--- a/src/helpers/browser.jsx
+++ b/src/helpers/browser.jsx
@@ -1,0 +1,10 @@
+import { BrowserExtension } from "@raycast/api";
+
+export const getBrowserTab = async () => {
+  try {
+    return await BrowserExtension.getContent({ format: "markdown" });
+  } catch (e) {
+    console.log(e);
+    return "Error getting browser tab content.";
+  }
+};

--- a/src/helpers/customCommands.jsx
+++ b/src/helpers/customCommands.jsx
@@ -1,5 +1,7 @@
 import { Storage } from "../api/storage";
+
 import { Clipboard } from "@raycast/api";
+import { getBrowserTab } from "./browser";
 
 export class CustomCommand {
   constructor({ name = "", prompt = "", id = Date.now().toString(), options = {} }) {
@@ -61,6 +63,9 @@ export class CustomCommand {
       case "day":
         // e.g. Monday
         processed = new Date().toLocaleDateString([], { weekday: "long" });
+        break;
+      case "browser-tab":
+        processed = await getBrowserTab();
         break;
       default:
         processed = t;


### PR DESCRIPTION
- Added the "Ask About Browser Tab" command (disabled by default).
- Added the {browser-tab} dynamic placeholder.

Tested to be working on Brave.

fixes #138