### PR TITLE
Improve chats order + large optimisation in AI Chat

### DIFF
--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -9,9 +9,9 @@ import {
   List,
   showToast,
   Toast,
-  useNavigation,
+  useNavigation
 } from "@raycast/api";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { Storage } from "./api/storage.js";
 import { Preferences } from "./api/preferences.js";
@@ -25,7 +25,7 @@ import { autoCheckForUpdates } from "./helpers/update.jsx";
 import { plainTextMarkdown } from "./helpers/markdown.js";
 import { confirmClearData, tryRecoverJSON } from "./helpers/aiChatHelper.jsx";
 
-import { MessagePair, format_chat_to_prompt, pairs_to_messages } from "./classes/message.js";
+import { format_chat_to_prompt, MessagePair, pairs_to_messages } from "./classes/message.js";
 
 import { formatResponse, getChatResponse, getChatResponseSync } from "./api/gpt.jsx";
 import * as providers from "./api/providers.js";
@@ -34,8 +34,15 @@ import { ChatProvidersReact } from "./api/providers_react.jsx";
 import { getAIPresets, getPreset } from "./helpers/presets.jsx";
 
 // Web search module
-import { getFormattedWebResult, has_native_web_search, web_search_mode } from "./api/tools/web";
-import { webSystemPrompt, systemResponse, webToken, webTokenEnd } from "./api/tools/web";
+import {
+  getFormattedWebResult,
+  has_native_web_search,
+  systemResponse,
+  web_search_mode,
+  webSystemPrompt,
+  webToken,
+  webTokenEnd
+} from "./api/tools/web";
 
 let generationStatus = { stop: false, loading: false, updateCurrentResponse: false };
 let get_status = () => generationStatus.stop;
@@ -976,7 +983,9 @@ export default function Chat({ launchContext }) {
               setChatData((oldData) => {
                 let newChatData = structuredClone(oldData);
                 let chat = getCurrentChatFromChatData(newChatData);
+
                 chat.pinned = !chat.pinned;
+                newChatData.chats = reorderChats(newChatData.chats);
 
                 toast(Toast.Style.Success, chat.pinned ? "Chat pinned" : "Chat unpinned");
                 return newChatData;
@@ -1270,13 +1279,26 @@ const isChatEmpty = (chat) => {
   return true;
 };
 
+const reorderChatsWithSections = (chats) => {
+  // usememo on this
+  return useMemo(() => {
+    let pinned = [],
+      unpinned = [];
+    for (const chat of chats) {
+      if (chat.pinned) pinned.push(chat);
+      else unpinned.push(chat);
+    }
+    return { pinned, unpinned };
+  }, [chats]);
+};
+
+const reorderChats = (chats) => {
+  let { pinned, unpinned } = reorderChatsWithSections(chats);
+  return [...pinned, ...unpinned];
+};
+
 const to_list_dropdown_items = (chats) => {
-  let pinned = [],
-    unpinned = [];
-  for (const chat of chats) {
-    if (chat.pinned) pinned.push(chat);
-    else unpinned.push(chat);
-  }
+  const { pinned, unpinned } = reorderChatsWithSections(chats);
   return (
     <>
       <List.Dropdown.Section title="Pinned">

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -9,7 +9,7 @@ import {
   List,
   showToast,
   Toast,
-  useNavigation
+  useNavigation,
 } from "@raycast/api";
 import { useEffect, useMemo, useState } from "react";
 
@@ -41,7 +41,7 @@ import {
   web_search_mode,
   webSystemPrompt,
   webToken,
-  webTokenEnd
+  webTokenEnd,
 } from "./api/tools/web";
 
 let generationStatus = { stop: false, loading: false, updateCurrentResponse: false };
@@ -1213,6 +1213,9 @@ export default function Chat({ launchContext }) {
 
   const [searchText, setSearchText] = useState("");
 
+  // Memoize the chat dropdown items
+  const chatDropdownItems = useMemo(() => to_list_dropdown_items(chatData), [chatData?.chats]);
+
   return chatData === null ? (
     <List searchText={searchText} onSearchTextChange={setSearchText}>
       <List.EmptyView icon={Icon.SpeechBubble} title="Ask GPT Anything..." actions={help_action_panel("aiChat")} />
@@ -1231,7 +1234,7 @@ export default function Chat({ launchContext }) {
           }}
           value={chatData.currentChat}
         >
-          {to_list_dropdown_items(chatData.chats)}
+          {chatDropdownItems}
         </List.Dropdown>
       }
     >
@@ -1280,16 +1283,13 @@ const isChatEmpty = (chat) => {
 };
 
 const reorderChatsWithSections = (chats) => {
-  // usememo on this
-  return useMemo(() => {
-    let pinned = [],
-      unpinned = [];
-    for (const chat of chats) {
-      if (chat.pinned) pinned.push(chat);
-      else unpinned.push(chat);
-    }
-    return { pinned, unpinned };
-  }, [chats]);
+  let pinned = [],
+    unpinned = [];
+  for (const chat of chats) {
+    if (chat.pinned) pinned.push(chat);
+    else unpinned.push(chat);
+  }
+  return { pinned, unpinned };
 };
 
 const reorderChats = (chats) => {
@@ -1297,8 +1297,8 @@ const reorderChats = (chats) => {
   return [...pinned, ...unpinned];
 };
 
-const to_list_dropdown_items = (chats) => {
-  const { pinned, unpinned } = reorderChatsWithSections(chats);
+const to_list_dropdown_items = (chatData) => {
+  const { pinned, unpinned } = reorderChatsWithSections(chatData?.chats || []);
   return (
     <>
       <List.Dropdown.Section title="Pinned">


### PR DESCRIPTION
The ordering of chats is now consistent. Previously, when pinning a chat, the chats dropdown would update to order the pinned chat at the top, but the actual internal order in chatData.chats would stay the same. This causes the "Next Chat" and "Previous Chat" actions to behave inconsistently.

Now, the internal order is updated, so that it's the exact same as displayed in the chats dropdown.

Additionally, a large optimisation: we memoize the chats dropdown so it's only updated when the chats array actually changes. (The current selected chat is still passed correctly to the dropdown because it's not memoized; similarly, the dropdown is not re-rendered when currentChat changes.) 

This is very large because the dropdown used to unnecessarily re-render upon typing anything in the search bar.