### PR TITLE
Fix DuckDuckGo web search

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ installation from source is extremely simple.
    clone the repository.
 2. Navigate to the directory, and open a Terminal window at the downloaded folder.
 3. Run `npm ci --production` to install required dependencies.
-4. Run `npm run dev` to build and import the extension.
+4. (Optional) Run `pip install -r requirements.txt` to install Python dependencies. These are required for
+   some features, e.g. web search.
+5. Run `npm run dev` to build and import the extension.
 
 The extension, and its full set of commands, should then show up in your Raycast app.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.80.0",
-        "duck-duck-scrape": "^2.2.5",
         "fetch-to-curl": "^0.6.0",
         "g4f-image": "^1.2.0",
         "gemini-g4f": "^12.3.10-beta.1",
@@ -939,6 +938,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -1017,18 +1037,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/duck-duck-scrape": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/duck-duck-scrape/-/duck-duck-scrape-2.2.5.tgz",
-      "integrity": "sha512-RTu/Ag5LhgD/j1l2zVGCwTINBoEYCffl58nMoBjtXWJG8tTex72h3gxpDjAr8jVqFaBvhgASNKTUsE31JeqYgw==",
-      "dependencies": {
-        "html-entities": "^2.3.3",
-        "needle": "^3.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/Snazzah"
       }
     },
     "node_modules/emoji-regex": {
@@ -1718,21 +1726,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/html-entities": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
-      "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/mdevils"
-        },
-        {
-          "type": "patreon",
-          "url": "https://patreon.com/mdevils"
-        }
-      ]
-    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -1757,17 +1750,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -1908,12 +1890,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2090,21 +2066,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
-    },
-    "node_modules/needle": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
-      "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
-      "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
-      }
     },
     "node_modules/netmask": {
       "version": "2.0.2",
@@ -2501,16 +2462,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -2951,21 +2902,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
       "engines": {
         "node": ">= 8"
       }

--- a/package.json
+++ b/package.json
@@ -826,7 +826,6 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.80.0",
-    "duck-duck-scrape": "^2.2.5",
     "fetch-to-curl": "^0.6.0",
     "g4f-image": "^1.2.0",
     "gemini-g4f": "^12.3.10-beta.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+duckduckgo-search>6.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-duckduckgo-search>6.3.4
+duckduckgo-search>=6.3.5

--- a/src/api/tools/ddgs.js
+++ b/src/api/tools/ddgs.js
@@ -12,7 +12,7 @@ import fs from "fs";
 export async function ddgsRequest(query, { maxResults = 15 } = {}) {
   query = escapeString(query);
 
-  const ddgs_cmd = `ddgs text -k '${query}' -s off -m ${maxResults} -o json -f "ddgs_results"`;
+  const ddgs_cmd = `ddgs text -k '${query}' -s off -m ${maxResults} -o "ddgs_results.json"`;
   const cwd = getSupportPath();
 
   const childProcess = exec(ddgs_cmd, {

--- a/src/api/tools/ddgs.js
+++ b/src/api/tools/ddgs.js
@@ -33,5 +33,8 @@ export async function ddgsRequest(query, { maxResults = 15 } = {}) {
   let results = fs.readFileSync(`${cwd}/ddgs_results.json`, "utf8");
   results = JSON.parse(results);
 
+  // clean up the file
+  fs.writeFileSync(`${cwd}/ddgs_results.json`, "");
+
   return results;
 }

--- a/src/api/tools/ddgs.js
+++ b/src/api/tools/ddgs.js
@@ -4,15 +4,15 @@
 
 import { exec } from "child_process";
 import { DEFAULT_ENV } from "#root/src/helpers/env.js";
-import { getSupportPath } from "#root/src/helpers/helper.js";
+import { escapeString, getSupportPath } from "#root/src/helpers/helper.js";
 import fs from "fs";
 
 // Return an array of the search results.
 // Each result is of the form: {title, href, body}
 export async function ddgsRequest(query, { maxResults = 15 } = {}) {
-  query = encodeURIComponent(query);
+  query = escapeString(query);
 
-  const ddgs_cmd = `ddgs text -k "${query}" -s off -m ${maxResults} -o json -f "ddgs_results"`;
+  const ddgs_cmd = `ddgs text -k '${query}' -s off -m ${maxResults} -o json -f "ddgs_results"`;
   const cwd = getSupportPath();
 
   const childProcess = exec(ddgs_cmd, {

--- a/src/api/tools/ddgs.js
+++ b/src/api/tools/ddgs.js
@@ -1,0 +1,36 @@
+// Similar to the CURL interface, the DDGS interface is used to communicate
+// with the `ddgs` CLI to perform DuckDuckGo searches.
+// REQUIREMENT: `pip install duckduckgo-search` in order to install the `ddgs` CLI.
+
+import { exec } from "child_process";
+import { DEFAULT_ENV } from "#root/src/helpers/env.js";
+import { getSupportPath } from "#root/src/helpers/helper.js";
+import fs from "fs";
+
+// Return an array of the search results.
+// Each result is of the form: {title, href, body}
+export async function ddgsRequest(query, { maxResults = 15 } = {}) {
+  query = encodeURIComponent(query);
+
+  const ddgs_cmd = `ddgs text -k "${query}" -s off -m ${maxResults} -o json -f "ddgs_results"`;
+  const cwd = getSupportPath();
+
+  const childProcess = exec(ddgs_cmd, {
+    env: DEFAULT_ENV,
+    cwd: cwd,
+  });
+
+  const exitCode = await new Promise((resolve, reject) => {
+    childProcess.on("exit", () => resolve(0));
+    childProcess.on("error", (err) => reject(err));
+  });
+
+  if (exitCode !== 0) {
+    throw new Error(`ddgs exited with code ${exitCode}`);
+  }
+
+  let results = fs.readFileSync(`${cwd}/ddgs_results.json`, "utf8");
+  results = JSON.parse(results);
+
+  return results;
+}

--- a/src/api/tools/ddgs.js
+++ b/src/api/tools/ddgs.js
@@ -4,7 +4,8 @@
 
 import { exec } from "child_process";
 import { DEFAULT_ENV } from "#root/src/helpers/env.js";
-import { escapeString, getSupportPath } from "#root/src/helpers/helper.js";
+import { escapeString } from "#root/src/helpers/helper.js";
+import { getSupportPath } from "#root/src/helpers/extension_helper.js";
 import fs from "fs";
 
 // Return an array of the search results.

--- a/src/api/tools/web.jsx
+++ b/src/api/tools/web.jsx
@@ -1,7 +1,7 @@
 import { Toast, showToast } from "@raycast/api";
 import * as providers from "../providers.js";
 
-import * as DDG from "duck-duck-scrape";
+import { ddgsRequest } from "#root/src/api/tools/ddgs.js";
 import { Preferences } from "../preferences.js";
 
 export const webToken = "<|web_search|>",
@@ -68,10 +68,8 @@ export const getWebResult = async (query) => {
   await showToast(Toast.Style.Animated, "Searching the web");
 
   try {
-    const searchResults = await DDG.search(query, {
-      safeSearch: DDG.SafeSearchType.OFF,
-    });
-    return processWebResults(searchResults.results);
+    const results = await ddgsRequest(query);
+    return processWebResults(results);
   } catch (e) {
     await showToast(Toast.Style.Failure, "Web search failed");
     return "No results found.";
@@ -88,7 +86,7 @@ export const processWebResults = (results, maxResults = 15) => {
   let answer = "";
   for (let i = 0; i < Math.min(results.length, maxResults); i++) {
     let x = results[i];
-    let rst = `${i + 1}.\nURL: ${x["url"]}\nTitle: ${x["title"]}\nContent: ${x["description"]}\n\n`;
+    let rst = `${i + 1}.\nURL: ${x["href"]}\nTitle: ${x["title"]}\nContent: ${x["body"]}\n\n`;
     answer += rst;
   }
   return answer;

--- a/src/helpers/env.js
+++ b/src/helpers/env.js
@@ -1,0 +1,7 @@
+export const DEFAULT_PATH =
+  "/opt/homebrew/opt/llvm/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin";
+
+export const DEFAULT_ENV = {
+  ...process.env,
+  PATH: DEFAULT_PATH,
+};

--- a/src/helpers/helper.js
+++ b/src/helpers/helper.js
@@ -190,3 +190,12 @@ export const current_datetime = () => {
     second: "2-digit",
   });
 };
+
+export const escapeString = (str) => {
+  // https://github.com/leoek/fetch-to-curl/blob/092db367955f80280d458c1e5af144e9b0f42114/src/main.js#L89C10-L89C37
+  return str.replace(/'/g, `'\\''`);
+};
+
+export const escapeObject = (obj) => {
+  return escapeString(JSON.stringify(obj));
+};


### PR DESCRIPTION
duck-duck-scrape is unmaintained and doesn't work anymore.

We use the duckduckgo-search Python package instead. It is added to requirements.txt as an optional dependency.