### PR TITLE
Optimise response formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -843,7 +843,7 @@
   "scripts": {
     "build": "ray build -e dist",
     "dev": "ray develop",
-    "fix-lint": "ray lint --fix",
+    "fix-lint": "ray lint --fix --relaxed",
     "lint": "ray lint",
     "publish": "npx @raycast/api@latest publish"
   }

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -27,7 +27,7 @@ import { confirmClearData, tryRecoverJSON } from "./helpers/aiChatHelper.jsx";
 
 import { format_chat_to_prompt, MessagePair, pairs_to_messages } from "./classes/message.js";
 
-import { formatResponse, getChatResponse, getChatResponseSync } from "./api/gpt.jsx";
+import { getChatResponse, getChatResponseSync } from "./api/gpt.jsx";
 import * as providers from "./api/providers.js";
 import { ChatProvidersReact } from "./api/providers_react.jsx";
 

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -322,7 +322,6 @@ export default function Chat({ launchContext }) {
       const _handler = async (new_message) => {
         i++;
         response = new_message;
-        response = formatResponse(response, info.provider);
         setCurrentChatMessage(currentChatData, setCurrentChatData, messageID, { response: response });
 
         if (generationStatus.updateCurrentResponse) {

--- a/src/api/Providers/blackbox.js
+++ b/src/api/Providers/blackbox.js
@@ -155,13 +155,15 @@ export const BlackboxProvider = {
 
           // Update 22/11/24: as part of ensuring consistent formatting, we now format the response before yielding it.
           // this is done by delaying the first few chunks of the response.
-          if (i < chunkDelay) {
-            i++;
-            continue;
-          } else if (first) {
-            first = false;
-            yield formatResponse(text, this);
-            continue;
+          if (first) {
+            if (i < chunkDelay) {
+              i++;
+              continue;
+            } else {
+              first = false;
+              yield formatResponse(text, this);
+              continue;
+            }
           }
 
           yield chunk;

--- a/src/api/gpt.jsx
+++ b/src/api/gpt.jsx
@@ -196,7 +196,6 @@ export default (
 
         const _handler = (new_message) => {
           response = new_message;
-          response = formatResponse(response, info.provider);
           setMarkdown(response);
           setLastResponse(response);
 
@@ -470,7 +469,6 @@ export const chatCompletion = async (info, chat, options, stream_update = null, 
   // stream = false
   if (typeof response === "string") {
     // will not be a string if stream is enabled
-    response = formatResponse(response, provider);
     return response;
   }
 
@@ -511,42 +509,6 @@ export const getChatResponseSync = async (currentChat, query = null) => {
   for await (const chunk of processChunks(r, info.provider)) {
     response = chunk;
   }
-  response = formatResponse(response, info.provider);
-  return response;
-};
-
-// format response using some heuristics
-export const formatResponse = (response, provider = null) => {
-  // eslint-disable-next-line no-constant-condition
-  if (false && (provider.name === "Nexra" || provider.name === "BestIM")) {
-    // replace escape characters: \n with a real newline, \t with a real tab, etc.
-    response = response.replace(/\\n/g, "\n");
-    response = response.replace(/\\t/g, "\t");
-    response = response.replace(/\\r/g, "\r");
-    response = response.replace(/\\'/g, "'");
-    response = response.replace(/\\"/g, '"');
-
-    // remove all remaining backslashes
-    response = response.replace(/\\/g, "");
-
-    // remove <sup>, </sup> tags (not supported apparently)
-    response = response.replace(/<sup>/g, "");
-    response = response.replace(/<\/sup>/g, "");
-  }
-
-  if (provider.name === "Blackbox") {
-    // remove version number - example: remove $@$v=v1.13$@$ or $@$v=undefined%@$
-    response = response.replace(/\$@\$v=.{1,30}\$@\$/, "");
-
-    // remove sources - the chunk of text starting with $~~~$[ and ending with ]$~~~$
-    // as well as everything before it
-    const regex = /\$~~~\$\[[^]*]\$~~~\$/;
-    let match = response.match(regex);
-    if (match) {
-      response = response.substring(match.index + match[0].length);
-    }
-  }
-
   return response;
 };
 

--- a/src/helpers/helper.js
+++ b/src/helpers/helper.js
@@ -208,3 +208,38 @@ export const stringToKeyboardShortcut = (str) => {
 
   return { modifiers, key };
 };
+
+// format response using some heuristics
+export const formatResponse = (response, provider = null) => {
+  // eslint-disable-next-line no-constant-condition
+  if (false && (provider.name === "Nexra" || provider.name === "BestIM")) {
+    // replace escape characters: \n with a real newline, \t with a real tab, etc.
+    response = response.replace(/\\n/g, "\n");
+    response = response.replace(/\\t/g, "\t");
+    response = response.replace(/\\r/g, "\r");
+    response = response.replace(/\\'/g, "'");
+    response = response.replace(/\\"/g, '"');
+
+    // remove all remaining backslashes
+    response = response.replace(/\\/g, "");
+
+    // remove <sup>, </sup> tags (not supported apparently)
+    response = response.replace(/<sup>/g, "");
+    response = response.replace(/<\/sup>/g, "");
+  }
+
+  if (provider.name === "Blackbox") {
+    // remove version number - example: remove $@$v=v1.13$@$ or $@$v=undefined%@$
+    response = response.replace(/\$@\$v=.{1,30}\$@\$/, "");
+
+    // remove sources - the chunk of text starting with $~~~$[ and ending with ]$~~~$
+    // as well as everything before it
+    const regex = /\$~~~\$\[[^]*]\$~~~\$/;
+    let match = response.match(regex);
+    if (match) {
+      response = response.substring(match.index + match[0].length);
+    }
+  }
+
+  return response;
+};


### PR DESCRIPTION
formatResponse is no longer called in the generation function itself. Instead, it is used by the provider. It makes the generation code less messy.

This also makes the responses consistent between what the provider generates, and what is actually displayed.

Lastly, this is a large performance optimisation since formatResponse is now called only when necessary, instead of being called after every chunk.