### PR TITLE
Add Paste action to AI Chat and AI Commands

### DIFF
--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -671,6 +671,7 @@ export default function Chat({ launchContext }) {
 
   let ComposeMessageComponent = () => {
     const { pop } = useNavigation();
+    const [input, setInput] = useState({ message: searchText, files: [] });
 
     return (
       <Form
@@ -684,11 +685,38 @@ export default function Chat({ launchContext }) {
                 await sendToGPT(values);
               }}
             />
+            <Action
+              title="Paste from Clipboard"
+              icon={Icon.Clipboard}
+              onAction={async () => {
+                let { text, file } = await Clipboard.read();
+                setInput((oldInput) => {
+                  let newInput = structuredClone(oldInput);
+                  newInput.message = text;
+                  if (file) {
+                    newInput.files = [...oldInput.files, file];
+                  }
+                  return newInput;
+                });
+                await toast(Toast.Style.Success, "Pasted from clipboard");
+              }}
+              shortcut={{ modifiers: ["cmd"], key: "v" }}
+            />
           </ActionPanel>
         }
       >
-        <Form.TextArea id="message" title="Message" defaultValue={searchText} />
-        <Form.FilePicker title="Upload Files" id="files" />
+        <Form.TextArea
+          id="message"
+          title="Message"
+          value={input.message}
+          onChange={(message) => setInput({ ...input, message })}
+        />
+        <Form.FilePicker
+          id="files"
+          title="Upload Files"
+          value={input.files}
+          onChange={(files) => setInput({ ...input, files })}
+        />
       </Form>
     );
   };

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -19,7 +19,7 @@ import { init } from "#root/src/api/init.js";
 
 import { watch } from "node:fs/promises";
 
-import { current_datetime, formatDate, removePrefix } from "./helpers/helper.js";
+import { current_datetime, formatDate, removePrefix, getFileFromURL } from "./helpers/helper.js";
 import { plainTextMarkdown } from "./helpers/markdown.js";
 import throttle, { AIChatDelayFunction } from "#root/src/helpers/throttle.js";
 
@@ -669,9 +669,20 @@ export default function Chat({ launchContext }) {
     );
   };
 
-  let ComposeMessageComponent = () => {
+  let ComposeMessageComponent = ({ idx }) => {
+    // if idx is provided, then we are editing an existing message.
+    // otherwise, we are composing a new message.
+    const isEditing = idx !== undefined;
+    if (isEditing && currentChatData.messages.length === 0) {
+      toast(Toast.Style.Failure, "No messages in chat");
+      return;
+    }
+
     const { pop } = useNavigation();
-    const [input, setInput] = useState({ message: searchText, files: [] });
+    const [input, setInput] = useState({
+      message: isEditing ? currentChatData.messages[idx].first.content : searchText,
+      files: isEditing ? currentChatData.messages[idx].files : [],
+    });
 
     return (
       <Form
@@ -682,7 +693,11 @@ export default function Chat({ launchContext }) {
               onSubmit={async (values) => {
                 setSearchText("");
                 pop();
-                await sendToGPT(values);
+                if (isEditing) {
+                  await resendMessage(currentChatData, idx, values);
+                } else {
+                  await sendToGPT(values);
+                }
               }}
             />
             <Action
@@ -692,13 +707,16 @@ export default function Chat({ launchContext }) {
                 let { text, file } = await Clipboard.read();
                 setInput((oldInput) => {
                   let newInput = structuredClone(oldInput);
-                  newInput.message = text;
                   if (file) {
-                    newInput.files = [...oldInput.files, file];
+                    file = getFileFromURL(file);
+                    newInput.files = [...(oldInput.files ?? []), file];
+                  } else {
+                    // Only set the text if there is no file, otherwise it's just the file name
+                    newInput.message += text;
                   }
                   return newInput;
                 });
-                await toast(Toast.Style.Success, "Pasted from clipboard");
+                // await toast(Toast.Style.Success, "Pasted from clipboard");
               }}
               shortcut={{ modifiers: ["cmd"], key: "v" }}
             />
@@ -714,47 +732,16 @@ export default function Chat({ launchContext }) {
         <Form.FilePicker
           id="files"
           title="Upload Files"
-          value={input.files}
+          value={input.files ?? []}
           onChange={(files) => setInput({ ...input, files })}
         />
       </Form>
     );
   };
 
-  let EditMessageComponent = ({ idx }) => {
-    if (currentChatData.messages.length === 0) {
-      toast(Toast.Style.Failure, "No messages in chat");
-      return;
-    }
-
-    const message = currentChatData.messages[idx].first.content;
-    const files = currentChatData.messages[idx].files;
-
-    const { pop } = useNavigation();
-
-    return (
-      <Form
-        actions={
-          <ActionPanel>
-            <Action.SubmitForm
-              title="Edit Message"
-              onSubmit={async (values) => {
-                pop();
-                await resendMessage(currentChatData, idx, values.message, values.files);
-              }}
-            />
-          </ActionPanel>
-        }
-      >
-        <Form.TextArea title="Message" id="message" defaultValue={message} />
-        <Form.FilePicker title="Upload Files" id="files" defaultValue={files} />
-      </Form>
-    );
-  };
-
-  let resendMessage = async (currentChatData, idx, newMessage = null, newFiles = null) => {
-    if (newMessage) currentChatData.messages[idx].first.content = newMessage;
-    if (newFiles) currentChatData.messages[idx].files = newFiles;
+  let resendMessage = async (currentChatData, idx, newMessage = null) => {
+    if (newMessage?.message) currentChatData.messages[idx].first.content = newMessage.message;
+    if (newMessage?.files) currentChatData.messages[idx].files = newMessage.files;
 
     currentChatData.messages[idx].second.content = "";
     currentChatData.messages[idx].finished = false;
@@ -1010,7 +997,7 @@ export default function Chat({ launchContext }) {
           <Action.Push
             icon={Icon.TextCursor}
             title="Edit Message"
-            target={<EditMessageComponent idx={idx} />}
+            target={<ComposeMessageComponent idx={idx} />}
             shortcut={{ modifiers: ["cmd", "shift"], key: "e" }}
           />
           <Action

--- a/src/aiChat.jsx
+++ b/src/aiChat.jsx
@@ -701,7 +701,7 @@ export default function Chat({ launchContext }) {
               }}
             />
             <Action
-              title="Paste from Clipboard"
+              title="Paste"
               icon={Icon.Clipboard}
               onAction={async () => {
                 let { text, file } = await Clipboard.read();
@@ -716,7 +716,6 @@ export default function Chat({ launchContext }) {
                   }
                   return newInput;
                 });
-                // await toast(Toast.Style.Success, "Pasted from clipboard");
               }}
               shortcut={{ modifiers: ["cmd"], key: "v" }}
             />

--- a/src/api/Providers/blackbox.js
+++ b/src/api/Providers/blackbox.js
@@ -1,5 +1,5 @@
 import fetch from "#root/src/api/fetch.js";
-import { format_chat_to_prompt } from "../../classes/message.js";
+import { messages_to_json, format_chat_to_prompt } from "../../classes/message.js";
 import { randomBytes, randomUUID } from "crypto";
 import { Storage } from "../storage.js";
 import { formatResponse } from "#root/src/helpers/helper.js";
@@ -84,6 +84,7 @@ export const BlackboxProvider = {
 
     // The chat is truncated to ~4 messages by the provider, so we reformat it
     // to at most 3 messages, with the last message being the prompt.
+    chat = messages_to_json(chat);
     let prompt = chat.pop().content; // remove last message
     if (chat.length > 0) {
       console.assert(chat.length > 1);

--- a/src/helpers/helper.js
+++ b/src/helpers/helper.js
@@ -247,3 +247,7 @@ export const formatResponse = (response, provider = null) => {
 export const clamp = (num, min, max) => {
   return Math.min(Math.max(num, min), max);
 };
+
+export const getFileFromURL = (file) => {
+  return removePrefix(file, "file://");
+};


### PR DESCRIPTION
The Paste action now overrides the behavior for Cmd+V. 

It uses the Raycast API to fetch the text and file (if any) from the Clipboard, then updates the input accordingly.

This is available in the Compose Message action in AI Chat, as well as in the Form views of all AI Commands.