### PR TITLE
fix installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ installation from source is extremely simple.
    clone the repository.
 2. Navigate to the directory, and open a Terminal window at the downloaded folder.
 3. Run `npm ci --production` to install required dependencies.
-4. (Optional) Run `pip3 install -r requirements.txt` to install Python dependencies. These are required for
-   some features, e.g. web search.
-5. Run `npm run dev` to build and import the extension.
+4. Run `npm run dev` to build and import the extension.
 
 The extension, and its full set of commands, should then show up in your Raycast app.
 


### PR DESCRIPTION
I just ran into the closed issue #170.

@XInTheDark: In the issue you state that [don't need to install anything in pip at this moment](https://github.com/XInTheDark/raycast-g4f/issues/170#issuecomment-2566543434).

So can the line just be removed from the README?